### PR TITLE
Make the entire RepositoryFetchFunction use worker threads

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryFetchFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/bazel/repository/RepositoryFetchFunction.java
@@ -26,7 +26,6 @@ import com.google.devtools.build.lib.actions.FileValue;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.bazel.bzlmod.NonRegistryOverride;
 import com.google.devtools.build.lib.bazel.bzlmod.VendorFileValue;
-import com.google.devtools.build.lib.bazel.repository.DigestWriter.RepoDirectoryState;
 import com.google.devtools.build.lib.bazel.repository.RepositoryFunctionException.AlreadyReportedRepositoryAccessException;
 import com.google.devtools.build.lib.bazel.repository.cache.LocalRepoContentsCache;
 import com.google.devtools.build.lib.bazel.repository.cache.LocalRepoContentsCache.CandidateRepo;
@@ -50,6 +49,7 @@ import com.google.devtools.build.lib.repository.RepositoryFetchProgress;
 import com.google.devtools.build.lib.rules.repository.RepoRecordedInput;
 import com.google.devtools.build.lib.rules.repository.RepositoryDirectoryValue;
 import com.google.devtools.build.lib.rules.repository.RepositoryDirectoryValue.Failure;
+import com.google.devtools.build.lib.rules.repository.RepositoryDirectoryValue.Success;
 import com.google.devtools.build.lib.runtime.ProcessWrapper;
 import com.google.devtools.build.lib.runtime.RemoteRepoContentsCache;
 import com.google.devtools.build.lib.runtime.RepositoryRemoteExecutor;
@@ -71,7 +71,6 @@ import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.SkyValue;
 import com.google.devtools.build.skyframe.WorkerSkyKeyComputeState;
 import java.io.IOException;
-import java.util.ArrayDeque;
 import java.util.Optional;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
@@ -136,29 +135,6 @@ public final class RepositoryFetchFunction implements SkyFunction {
     this.remoteRepoContentsCache = remoteRepoContentsCache;
   }
 
-  /**
-   * The result of the {@link #fetch} method.
-   *
-   * @param recordedInputValues Any recorded inputs (and their values) encountered during the fetch
-   *     of the repo. Changes to these inputs will result in the repo being refetched in the future.
-   * @param reproducible Whether the fetched repo contents are reproducible, hence cacheable.
-   */
-  private record FetchResult(
-      ImmutableList<RepoRecordedInput.WithValue> recordedInputValues,
-      Reproducibility reproducible) {}
-
-  private static class State extends WorkerSkyKeyComputeState<FetchResult> {
-    @Nullable FetchResult result;
-    // While checking whether a particular repo candidate (either the current contents under the
-    // external directory or a candidate repo in the local repo contents cache) is up-to-date, these
-    // hold opaque intermediate state that avoids repeating work, such as reading marker files, on
-    // Skyframe restarts.
-    @Nullable RepoDirectoryState.Indeterminate indeterminateState;
-    @Nullable RepoDirectoryState.Indeterminate candidateIndeterminateState;
-    // The candidate repos in the local repo contents cache that still have to be checked.
-    @Nullable ArrayDeque<CandidateRepo> candidateRepos;
-  }
-
   @Nullable
   @Override
   public SkyValue compute(SkyKey skyKey, Environment env)
@@ -178,232 +154,232 @@ public final class RepositoryFetchFunction implements SkyFunction {
 
     try (SilentCloseable c =
         Profiler.instance().profile(ProfilerTask.REPOSITORY_FETCH, repositoryName.toString())) {
-      Path repoRoot =
-          RepositoryUtils.getExternalRepositoryDirectory(directories)
-              .getRelative(repositoryName.getName());
-
-      RepoDefinition repoDefinition;
-      switch ((RepoDefinitionValue) env.getValue(RepoDefinitionValue.key(repositoryName))) {
-        case null -> {
-          return null;
-        }
-        case RepoDefinitionValue.NotFound() -> {
-          return new Failure(String.format("Repository '%s' is not defined", repositoryName));
-        }
-        case RepoDefinitionValue.RepoOverride(PathFragment repoPath) -> {
-          return setupOverride(repoPath, env, repoRoot, repositoryName);
-        }
-        case RepoDefinitionValue.Found(RepoDefinition rd) -> {
-          repoDefinition = rd;
+      // See below (the `catch CancellationException` clause) for why there's a `while` loop here.
+      while (true) {
+        var state = env.getState(WorkerSkyKeyComputeState<RepositoryDirectoryValue>::new);
+        try {
+          return state.startOrContinueWork(
+              env,
+              "starlark-repository-" + repositoryName.getName(),
+              (workerEnv) -> {
+                return computeInternal(workerEnv, repositoryName, starlarkSemantics);
+              });
+        } catch (ExecutionException e) {
+          Throwables.throwIfInstanceOf(e.getCause(), RepositoryFunctionException.class);
+          Throwables.throwIfInstanceOf(e.getCause(), InterruptedException.class);
+          Throwables.throwIfUnchecked(e.getCause());
+          throw new IllegalStateException(
+              "unexpected exception type: " + e.getCause().getClass(), e.getCause());
+        } catch (CancellationException e) {
+          // This can only happen if the state object was invalidated due to memory pressure, in
+          // which case we can simply reattempt the fetch. Show a message and continue into the next
+          // `while` iteration.
+          env.getListener()
+              .post(
+                  RepositoryFetchProgress.ongoing(
+                      repositoryName, "fetch interrupted due to memory pressure; restarting."));
         }
       }
+    }
+  }
 
-      var digestWriter =
-          DigestWriter.create(env, directories, repositoryName, repoDefinition, starlarkSemantics);
-      if (digestWriter == null) {
+  /**
+   * The actual SkyFunction logic, run in a worker thread. Note that, although the worker thread
+   * never sees Skyframe restarts, {@code env.valuesMissing()} can still be true due to deps in
+   * error. So this function still needs to return {@code null} when appropriate. See Javadoc of
+   * {@link WorkerSkyFunctionEnvironment} for more information.
+   */
+  @Nullable
+  private RepositoryDirectoryValue computeInternal(
+      Environment env, RepositoryName repositoryName, StarlarkSemantics starlarkSemantics)
+      throws InterruptedException, RepositoryFunctionException {
+    Path repoRoot =
+        RepositoryUtils.getExternalRepositoryDirectory(directories)
+            .getRelative(repositoryName.getName());
+
+    RepoDefinition repoDefinition;
+    switch ((RepoDefinitionValue) env.getValue(RepoDefinitionValue.key(repositoryName))) {
+      case null -> {
         return null;
       }
+      case RepoDefinitionValue.NotFound() -> {
+        return new Failure(String.format("Repository '%s' is not defined", repositoryName));
+      }
+      case RepoDefinitionValue.RepoOverride(PathFragment repoPath) -> {
+        return setupOverride(repoPath, env, repoRoot, repositoryName);
+      }
+      case RepoDefinitionValue.Found(RepoDefinition rd) -> {
+        repoDefinition = rd;
+      }
+    }
 
-      boolean excludeRepoFromVendoring = true;
-      if (RepositoryDirectoryValue.VENDOR_DIRECTORY.get(env).isPresent()) { // If vendor mode is on
-        VendorFileValue vendorFile = (VendorFileValue) env.getValue(VendorFileValue.KEY);
+    var digestWriter =
+        DigestWriter.create(env, directories, repositoryName, repoDefinition, starlarkSemantics);
+    if (digestWriter == null) {
+      return null;
+    }
+
+    boolean excludeRepoFromVendoring = true;
+    if (RepositoryDirectoryValue.VENDOR_DIRECTORY.get(env).isPresent()) { // If vendor mode is on
+      VendorFileValue vendorFile = (VendorFileValue) env.getValue(VendorFileValue.KEY);
+      if (env.valuesMissing()) {
+        return null;
+      }
+      boolean excludeRepoByDefault = isRepoExcludedFromVendoringByDefault(repoDefinition);
+      if (!excludeRepoByDefault && !vendorFile.ignoredRepos().contains(repositoryName)) {
+        RepositoryDirectoryValue repositoryDirectoryValue =
+            tryGettingValueUsingVendoredRepo(
+                env, repoRoot, repositoryName, digestWriter, vendorFile);
         if (env.valuesMissing()) {
           return null;
         }
-        boolean excludeRepoByDefault = isRepoExcludedFromVendoringByDefault(repoDefinition);
-        if (!excludeRepoByDefault && !vendorFile.ignoredRepos().contains(repositoryName)) {
-          RepositoryDirectoryValue repositoryDirectoryValue =
-              tryGettingValueUsingVendoredRepo(
-                  env, repoRoot, repositoryName, digestWriter, vendorFile);
-          if (env.valuesMissing()) {
-            return null;
-          }
-          if (repositoryDirectoryValue != null) {
-            return repositoryDirectoryValue;
-          }
-        }
-        excludeRepoFromVendoring =
-            excludeRepoByDefault
-                || vendorFile.ignoredRepos().contains(repositoryName)
-                || vendorFile.pinnedRepos().contains(repositoryName);
-      }
-
-      var state = env.getState(State::new);
-      if (shouldUseCachedRepoContents(env, repoDefinition)) {
-        // Make sure marker file is up-to-date; correctly describes the current repository state
-        var repoState =
-            digestWriter.areRepositoryAndMarkerFileConsistent(env, state.indeterminateState);
-        switch (repoState) {
-          case RepoDirectoryState.Indeterminate intermediateState -> {
-            state.indeterminateState = intermediateState;
-            return null;
-          }
-          case RepoDirectoryState.UpToDate ignored -> {
-            return new RepositoryDirectoryValue.Success(
-                Root.fromPath(repoRoot), excludeRepoFromVendoring);
-          }
-          case RepoDirectoryState.OutOfDate ignored -> {
-            // Fall through.
-          }
-        }
-
-        // Then check if the global repo contents cache has this.
-        if (repoContentsCache.isEnabled()) {
-          if (state.candidateRepos == null) {
-            state.candidateRepos =
-                new ArrayDeque<>(
-                    repoContentsCache.getCandidateRepos(digestWriter.predeclaredInputHash));
-          }
-          for (var it = state.candidateRepos.iterator(); it.hasNext(); ) {
-            CandidateRepo candidate = it.next();
-            repoState =
-                digestWriter.areRepositoryAndMarkerFileConsistent(
-                    env, candidate.recordedInputsFile(), state.candidateIndeterminateState);
-            switch (repoState) {
-              case RepoDirectoryState.Indeterminate intermediateState -> {
-                state.candidateIndeterminateState = intermediateState;
-                return null;
-              }
-              case RepoDirectoryState.UpToDate ignored -> {
-                if (setupOverride(
-                        candidate.contentsDir().asFragment(), env, repoRoot, repositoryName)
-                    == null) {
-                  return null;
-                }
-                candidate.touch();
-                return new RepositoryDirectoryValue.Success(
-                    Root.fromPath(repoRoot), excludeRepoFromVendoring);
-              }
-              case RepoDirectoryState.OutOfDate ignored -> {
-                // Reset for the next candidate.
-                state.candidateIndeterminateState = null;
-                // Remove from the state so that we don't check it again on a restart.
-                it.remove();
-              }
-            }
-          }
-        }
-
-        if (remoteRepoContentsCache != null) {
-          try {
-            if (remoteRepoContentsCache.lookupCache(
-                repositoryName, repoRoot, digestWriter.predeclaredInputHash, env.getListener())) {
-              return new RepositoryDirectoryValue.Success(
-                  Root.fromPath(repoRoot), excludeRepoFromVendoring);
-            }
-          } catch (IOException e) {
-            env.getListener()
-                .handle(
-                    Event.warn(
-                        "Remote repo contents cache lookup failed for %s: %s"
-                            .formatted(repositoryName, e.getMessage())));
-          }
+        if (repositoryDirectoryValue != null) {
+          return repositoryDirectoryValue;
         }
       }
+      excludeRepoFromVendoring =
+          excludeRepoByDefault
+              || vendorFile.ignoredRepos().contains(repositoryName)
+              || vendorFile.pinnedRepos().contains(repositoryName);
+    }
 
-      /* At this point: This is a force fetch, a local repository, OR The repository cache is old or
-      didn't exist. In any of those cases, we initiate the fetching process UNLESS this is offline
-      mode (fetching is disabled) */
-      if (!RepositoryDirectoryValue.FETCH_DISABLED.get(env)) {
-        // Fetching a repository is a long-running operation that can easily be interrupted. If it
-        // is and the marker file exists on disk, a new call of this method may treat this
-        // repository as valid even though it is in an inconsistent state. Clear the marker file and
-        // only recreate it after fetching is done to prevent this scenario.
-        DigestWriter.clearMarkerFile(directories, repositoryName);
-        FetchResult result = fetchAndHandleEvents(repoDefinition, repoRoot, env, skyKey);
-        if (result == null) {
-          return null;
-        }
-        digestWriter.writeMarkerFile(result.recordedInputValues());
-        if (result.reproducible() == Reproducibility.YES && !repoDefinition.repoRule().local()) {
-          // This repo is eligible for the local and remote repo contents cache.
-          if (repoContentsCache.isEnabled()) {
-            CandidateRepo newCacheEntry;
-            try {
-              newCacheEntry =
-                  repoContentsCache.moveToCache(
-                      repoRoot, digestWriter.markerPath, digestWriter.predeclaredInputHash);
-            } catch (IOException e) {
-              throw new RepositoryFunctionException(
-                  new IOException(
-                      "error moving repo %s into the repo contents cache: %s"
-                          .formatted(repositoryName, e.getMessage()),
-                      e),
-                  Transience.TRANSIENT);
-            }
-            // Upon the next restart, pick up the cache entry we just created.
-            state.candidateRepos = new ArrayDeque<>(ImmutableList.of(newCacheEntry));
-            Path cachedRepoDir = newCacheEntry.contentsDir();
-            // Don't forget to register a FileStateValue on the cache repo dir, so that we know to
-            // refetch if the cache entry gets GC'd from under us or the entire cache is deleted.
-            //
-            // Note that registering a FileValue dependency instead would lead to subtly incorrect
-            // behavior when the repo contents cache directory is deleted between builds:
-            // 1. We register a FileValue dependency on the cache entry.
-            // 2. Before the next build, the repo contents cache directory is deleted.
-            // 3. On the next build, FileSystemValueChecker invalidates the underlying
-            //    FileStateValue, which in turn results in the FileValue and the current
-            //    RepositoryDirectoryValue being marked as dirty.
-            // 4. Skyframe visits the dirty nodes bottom up to check for actual changes. In
-            //    particular, it reevaluates FileFunction before RepositoryFetchFunction and thus
-            //    the FileValue of the repo contents cache directory is locked in as non-existent
-            //    before RepositoryFetchFunction can recreate it.
-            // 5. Any other SkyFunction that depends on the FileValue of a file in the repo (e.g.
-            //    PackageFunction) will report that file as missing since the resolved path has a
-            //    parent that is non-existent.
-            // By using FileStateValue directly, which benefits from special logic built into
-            // DirtinessCheckerUtils that recognizes the repo contents cache directories with
-            // non-UUID names and prevents locking in their value during dirtiness checking, we
-            // avoid 4. and thus the incorrect missing file errors in 5.
-            if (env.getValue(
-                    FileStateValue.key(
-                        RootedPath.toRootedPath(
-                            Root.absoluteRoot(cachedRepoDir.getFileSystem()), cachedRepoDir)))
+    if (shouldUseCachedRepoContents(env, repoDefinition)) {
+      // Make sure marker file is up-to-date; correctly describes the current repository state
+      if (digestWriter.areRepositoryAndMarkerFileConsistent(env).isEmpty()) {
+        return new Success(Root.fromPath(repoRoot), excludeRepoFromVendoring);
+      }
+      if (env.valuesMissing()) {
+        return null;
+      }
+
+      // Then check if the local repo contents cache has this.
+      if (repoContentsCache.isEnabled()) {
+        ImmutableList<CandidateRepo> candidateRepos =
+            repoContentsCache.getCandidateRepos(digestWriter.predeclaredInputHash);
+        for (CandidateRepo candidate : candidateRepos) {
+          if (digestWriter
+              .areRepositoryAndMarkerFileConsistent(env, candidate.recordedInputsFile())
+              .isEmpty()) {
+            if (setupOverride(candidate.contentsDir().asFragment(), env, repoRoot, repositoryName)
                 == null) {
               return null;
             }
-            // This is never reached: the repo dir in the repo contents cache is created under a new
-            // UUID-named directory and thus the FileStateValue above will always be missing from
-            // Skyframe. After the restart, the repo will either encounter the just created cache
-            // entry as a candidate or will create a new one if it got GC'd in the meantime.
-            throw new IllegalStateException(
-                "FileStateValue unexpectedly present for " + cachedRepoDir);
+            candidate.touch();
+            return new Success(Root.fromPath(repoRoot), excludeRepoFromVendoring);
           }
-          if (remoteRepoContentsCache != null) {
-            remoteRepoContentsCache.addToCache(
-                repositoryName,
-                repoRoot,
-                digestWriter.markerPath,
-                digestWriter.predeclaredInputHash,
-                env.getListener());
+          if (env.valuesMissing()) {
+            return null;
           }
         }
-        return new RepositoryDirectoryValue.Success(
-            Root.fromPath(repoRoot), excludeRepoFromVendoring);
       }
 
-      if (!repoRoot.exists()) {
-        // The repository isn't on the file system, there is nothing we can do.
-        throw new RepositoryFunctionException(
-            new IOException(
-                "to fix, run\n\tbazel fetch //...\nExternal repository "
-                    + repositoryName
-                    + " not found and fetching repositories is disabled."),
-            Transience.TRANSIENT);
+      if (remoteRepoContentsCache != null) {
+        try {
+          if (remoteRepoContentsCache.lookupCache(
+              repositoryName, repoRoot, digestWriter.predeclaredInputHash, env.getListener())) {
+            return new Success(Root.fromPath(repoRoot), excludeRepoFromVendoring);
+          }
+        } catch (IOException e) {
+          env.getListener()
+              .handle(
+                  Event.warn(
+                      "Remote repo contents cache lookup failed for %s: %s"
+                          .formatted(repositoryName, e.getMessage())));
+        }
       }
-
-      // Try to build with whatever is on the file system and emit a warning.
-      env.getListener()
-          .handle(
-              Event.warn(
-                  String.format(
-                      "External repository '%s' is not up-to-date and fetching is disabled. To"
-                          + " update, run the build without the '--nofetch' command line option.",
-                      repositoryName)));
-
-      return new RepositoryDirectoryValue.Success(
-          Root.fromPath(repoRoot), excludeRepoFromVendoring);
     }
+
+    /* At this point: This is a force fetch, a local repository, OR The repository cache is old or
+    didn't exist. In any of those cases, we initiate the fetching process UNLESS this is offline
+    mode (fetching is disabled) */
+    if (!RepositoryDirectoryValue.FETCH_DISABLED.get(env)) {
+      // Fetching a repository is a long-running operation that can easily be interrupted. If it
+      // is and the marker file exists on disk, a new call of this method may treat this
+      // repository as valid even though it is in an inconsistent state. Clear the marker file and
+      // only recreate it after fetching is done to prevent this scenario.
+      DigestWriter.clearMarkerFile(directories, repositoryName);
+      FetchResult result = fetchAndHandleEvents(repoDefinition, repoRoot, env, repositoryName);
+      if (result == null) {
+        return null;
+      }
+      digestWriter.writeMarkerFile(result.recordedInputValues());
+      if (result.reproducible() == Reproducibility.YES && !repoDefinition.repoRule().local()) {
+        // This repo is eligible for the local and remote repo contents cache.
+        if (repoContentsCache.isEnabled()) {
+          CandidateRepo newCacheEntry;
+          try {
+            newCacheEntry =
+                repoContentsCache.moveToCache(
+                    repoRoot, digestWriter.markerPath, digestWriter.predeclaredInputHash);
+          } catch (IOException e) {
+            throw new RepositoryFunctionException(
+                new IOException(
+                    "error moving repo %s into the repo contents cache: %s"
+                        .formatted(repositoryName, e.getMessage()),
+                    e),
+                Transience.TRANSIENT);
+          }
+          Path cachedRepoDir = newCacheEntry.contentsDir();
+          RootedPath cachedRepoDirRootedPath =
+              RootedPath.toRootedPath(
+                  Root.absoluteRoot(cachedRepoDir.getFileSystem()), cachedRepoDir);
+          // Don't forget to register a FileStateValue on the cache repo dir, so that we know to
+          // refetch if the cache entry gets GC'd from under us or the entire cache is deleted.
+          //
+          // Note that registering a FileValue dependency instead would lead to subtly incorrect
+          // behavior when the repo contents cache directory is deleted between builds:
+          // 1. We register a FileValue dependency on the cache entry.
+          // 2. Before the next build, the repo contents cache directory is deleted.
+          // 3. On the next build, FileSystemValueChecker invalidates the underlying
+          //    FileStateValue, which in turn results in the FileValue and the current
+          //    RepositoryDirectoryValue being marked as dirty.
+          // 4. Skyframe visits the dirty nodes bottom up to check for actual changes. In
+          //    particular, it reevaluates FileFunction before RepositoryFetchFunction and thus
+          //    the FileValue of the repo contents cache directory is locked in as non-existent
+          //    before RepositoryFetchFunction can recreate it.
+          // 5. Any other SkyFunction that depends on the FileValue of a file in the repo (e.g.
+          //    PackageFunction) will report that file as missing since the resolved path has a
+          //    parent that is non-existent.
+          // By using FileStateValue directly, which benefits from special logic built into
+          // DirtinessCheckerUtils that recognizes the repo contents cache directories with
+          // non-UUID names and prevents locking in their value during dirtiness checking, we
+          // avoid 4. and thus the incorrect missing file errors in 5.
+          if (env.getValue(FileStateValue.key(cachedRepoDirRootedPath)) == null) {
+            return null;
+          }
+        }
+        if (remoteRepoContentsCache != null) {
+          remoteRepoContentsCache.addToCache(
+              repositoryName,
+              repoRoot,
+              digestWriter.markerPath,
+              digestWriter.predeclaredInputHash,
+              env.getListener());
+        }
+      }
+      return new Success(Root.fromPath(repoRoot), excludeRepoFromVendoring);
+    }
+
+    if (!repoRoot.exists()) {
+      // The repository isn't on the file system, there is nothing we can do.
+      throw new RepositoryFunctionException(
+          new IOException(
+              "to fix, run\n\tbazel fetch //...\nExternal repository "
+                  + repositoryName
+                  + " not found and fetching repositories is disabled."),
+          Transience.TRANSIENT);
+    }
+
+    // Try to build with whatever is on the file system and emit a warning.
+    env.getListener()
+        .handle(
+            Event.warn(
+                String.format(
+                    "External repository '%s' is not up-to-date and fetching is disabled. To"
+                        + " update, run the build without the '--nofetch' command line option.",
+                    repositoryName)));
+
+    return new Success(Root.fromPath(repoRoot), excludeRepoFromVendoring);
   }
 
   @Nullable
@@ -430,20 +406,17 @@ public final class RepositoryFetchFunction implements SkyFunction {
         return setupOverride(vendorRepoPath.asFragment(), env, repoRoot, repositoryName);
       }
 
-      var state = env.getState(State::new);
-      RepoDirectoryState vendoredRepoState =
-          digestWriter.areRepositoryAndMarkerFileConsistent(
-              env, vendorMarker, state.indeterminateState);
-      if (vendoredRepoState instanceof RepoDirectoryState.Indeterminate intermediateState) {
-        state.indeterminateState = intermediateState;
+      Optional<String> vendoredRepoOutOfDateReason =
+          digestWriter.areRepositoryAndMarkerFileConsistent(env, vendorMarker);
+      if (env.valuesMissing()) {
         return null;
       }
       // If our repo is up-to-date, or this is an offline build (--nofetch), then the vendored repo
       // is used.
-      if (vendoredRepoState instanceof RepoDirectoryState.UpToDate
+      if (vendoredRepoOutOfDateReason.isEmpty()
           || (!RepositoryDirectoryValue.IS_VENDOR_COMMAND.get(env)
               && RepositoryDirectoryValue.FETCH_DISABLED.get(env))) {
-        if (vendoredRepoState instanceof RepoDirectoryState.OutOfDate(String reason)) {
+        if (vendoredRepoOutOfDateReason.isPresent()) {
           env.getListener()
               .handle(
                   Event.warn(
@@ -451,7 +424,7 @@ public final class RepositoryFetchFunction implements SkyFunction {
                           "Vendored repository '%s' is out-of-date (%s) and fetching is disabled."
                               + " Run build without the '--nofetch' option or run"
                               + " the bazel vendor command to update it",
-                          repositoryName.getName(), reason)));
+                          repositoryName.getName(), vendoredRepoOutOfDateReason.get())));
         }
         return setupOverride(vendorRepoPath.asFragment(), env, repoRoot, repositoryName);
       } else if (!RepositoryDirectoryValue.IS_VENDOR_COMMAND
@@ -465,10 +438,8 @@ public final class RepositoryFetchFunction implements SkyFunction {
                         "Vendored repository '%s' is out-of-date (%s). The up-to-date version will"
                             + " be fetched into the external cache and used. To update the repo"
                             + " in the vendor directory, run the bazel vendor command",
-                        repositoryName.getName(),
-                        ((RepoDirectoryState.OutOfDate) vendoredRepoState).reason())));
+                        repositoryName.getName(), vendoredRepoOutOfDateReason.get())));
       }
-      state.indeterminateState = null;
     } else if (vendorFile.pinnedRepos().contains(repositoryName)) {
       throw new RepositoryFunctionException(
           new IOException(
@@ -495,14 +466,6 @@ public final class RepositoryFetchFunction implements SkyFunction {
    */
   private boolean shouldUseCachedRepoContents(Environment env, RepoDefinition repoDefinition)
       throws InterruptedException {
-    if (env.getState(State::new).result != null) {
-      // If this SkyFunction has finished fetching once, then we should always use the cached
-      // result. This means that we _very_ recently (as in, in the same command invocation) fetched
-      // this repo (possibly with --force or --configure), and are only here again due to a Skyframe
-      // restart very late into RepositoryDelegatorFunction.
-      return true;
-    }
-
     /* If fetching is enabled & this is a local repo: do NOT use cache!
      * Local repository are generally fast and do not rely on non-local data, making caching them
      * across server instances impractical. */
@@ -531,14 +494,13 @@ public final class RepositoryFetchFunction implements SkyFunction {
 
   @Nullable
   private FetchResult fetchAndHandleEvents(
-      RepoDefinition repoDefinition, Path repoRoot, Environment env, SkyKey skyKey)
+      RepoDefinition repoDefinition, Path repoRoot, Environment env, RepositoryName repoName)
       throws InterruptedException, RepositoryFunctionException {
-    RepositoryName repoName = (RepositoryName) skyKey.argument();
     env.getListener().post(RepositoryFetchProgress.ongoing(repoName, "starting"));
 
     FetchResult result;
     try {
-      result = fetch(repoDefinition, repoRoot, env, skyKey);
+      result = fetch(repoDefinition, repoRoot, env, repoName);
     } catch (RepositoryFunctionException e) {
       // Upon an exceptional exit, the fetching of that repository is over as well.
       env.getListener().post(RepositoryFetchProgress.finished(repoName));
@@ -573,51 +535,22 @@ public final class RepositoryFetchFunction implements SkyFunction {
     }
   }
 
-  @Nullable
-  private FetchResult fetch(
-      RepoDefinition repoDefinition, Path outputDirectory, Environment env, SkyKey key)
-      throws RepositoryFunctionException, InterruptedException {
-    // See below (the `catch CancellationException` clause) for why there's a `while` loop here.
-    while (true) {
-      var state = env.getState(State::new);
-      if (state.result != null) {
-        // Escape early if we've already finished fetching once. This can happen if
-        // a Skyframe restart is triggered _after_ fetch() is finished.
-        return state.result;
-      }
-      try {
-        state.result =
-            state.startOrContinueWork(
-                env,
-                "starlark-repository-" + repoDefinition.name(),
-                (workerEnv) -> {
-                  setupRepoRoot(outputDirectory);
-                  return fetchInternal(repoDefinition, outputDirectory, workerEnv, key);
-                });
-        return state.result;
-      } catch (ExecutionException e) {
-        Throwables.throwIfInstanceOf(e.getCause(), RepositoryFunctionException.class);
-        Throwables.throwIfInstanceOf(e.getCause(), InterruptedException.class);
-        Throwables.throwIfUnchecked(e.getCause());
-        throw new IllegalStateException(
-            "unexpected exception type: " + e.getCause().getClass(), e.getCause());
-      } catch (CancellationException e) {
-        // This can only happen if the state object was invalidated due to memory pressure, in
-        // which case we can simply reattempt the fetch. Show a message and continue into the next
-        // `while` iteration.
-        env.getListener()
-            .post(
-                RepositoryFetchProgress.ongoing(
-                    RepositoryName.createUnvalidated(repoDefinition.name()),
-                    "fetch interrupted due to memory pressure; restarting."));
-      }
-    }
-  }
+  /**
+   * The result of the {@link #fetch} method.
+   *
+   * @param recordedInputValues Any recorded inputs (and their values) encountered during the fetch
+   *     of the repo. Changes to these inputs will result in the repo being refetched in the future.
+   * @param reproducible Whether the fetched repo contents are reproducible, hence cacheable.
+   */
+  private record FetchResult(
+      ImmutableList<RepoRecordedInput.WithValue> recordedInputValues,
+      Reproducibility reproducible) {}
 
   @Nullable
-  private FetchResult fetchInternal(
-      RepoDefinition repoDefinition, Path outputDirectory, Environment env, SkyKey key)
+  private FetchResult fetch(
+      RepoDefinition repoDefinition, Path outputDirectory, Environment env, RepositoryName repoName)
       throws RepositoryFunctionException, InterruptedException {
+    setupRepoRoot(outputDirectory);
 
     String defInfo = RepositoryResolvedEvent.getRuleDefinitionInformation(repoDefinition);
     env.getListener()
@@ -681,8 +614,8 @@ public final class RepositoryFetchFunction implements SkyFunction {
           StarlarkThread.create(
               mu,
               starlarkSemantics,
-              "repository " + ((RepositoryName) key.argument()).getDisplayForm(mainRepoMapping),
-              SymbolGenerator.create(key));
+              "repository " + repoName.getDisplayForm(mainRepoMapping),
+              SymbolGenerator.create("fetching " + repoName));
       thread.setPrintHandler(Event.makeDebugPrintHandler(env.getListener()));
       starlarkRepositoryContext.storeRepoMappingRecorderInThread(thread);
 
@@ -863,7 +796,6 @@ public final class RepositoryFetchFunction implements SkyFunction {
           new IOException("No MODULE.bazel, REPO.bazel, or WORKSPACE file found in " + destination),
           Transience.TRANSIENT);
     }
-    return new RepositoryDirectoryValue.Success(
-        Root.fromPath(source), /* excludeFromVendoring= */ true);
+    return new Success(Root.fromPath(source), /* excludeFromVendoring= */ true);
   }
 }


### PR DESCRIPTION
CI results: https://buildkite.com/bazel/bazel-bazel-github-presubmit/builds/31199

looks to be a nice simplification!