### PR TITLE
Preserve empty factsVersions map in the lockfile merge driver

### DIFF
--- a/scripts/bazel-lockfile-merge.jq
+++ b/scripts/bazel-lockfile-merge.jq
@@ -72,7 +72,7 @@ def shallow_merge(f):
                   if length > 0 then group_by(.key) | shallow_merge({(.[0].key): shallow_merge(.value)}) else {} end
                 else null end),
         # Keep only non-zero versions, mirroring how Bazel writes the lockfile.
-        factsVersions: (if ($maxFactsVersions | with_entries(select(.value != 0)) | length) > 0 then
+        factsVersions: (if any(has("factsVersions")) then
                           $maxFactsVersions | with_entries(select(.value != 0))
                         else null end),
     }

--- a/scripts/bazel_lockfile_merge_test.sh
+++ b/scripts/bazel_lockfile_merge_test.sh
@@ -446,4 +446,24 @@ EOF
   diff -u expected left || fail "output differs"
 }
 
+# Regression test for https://github.com/bazelbuild/bazel/issues/29742.
+function test_merge_preserves_empty_facts_versions() {
+  cat > base <<'EOF'
+{
+  "lockFileVersion": 28,
+  "registryFileHashes": {},
+  "selectedYankedVersions": {},
+  "moduleExtensions": {},
+  "facts": {},
+  "factsVersions": {}
+}
+EOF
+  cp base left
+  cp base right
+  cp base expected
+
+  do_merge base left right
+  diff -u expected left || fail "output differs"
+}
+
 run_suite "Tests of bash completion of 'blaze' command."


### PR DESCRIPTION
Bazel writes an empty "factsVersions": {} map alongside "facts": {} once
the facts_version feature (#29556) is in effect, but the lockfile merge
driver only emitted factsVersions when it contained at least one non-zero
entry. An identity merge of a freshly generated lockfile therefore dropped
the empty factsVersions key, so running

  bazel run //src/test/tools/bzlmod:update_default_lock_file
  bazel test //scripts:bazel_lockfile_merge_test

failed with the merged output differing from the regenerated lockfile.

Emit factsVersions in parallel with facts: keep the key (possibly as an
empty object) whenever any input lockfile carries it, and omit it only for
lockfiles that predate the feature. Regenerate the default test lockfile so
it carries the empty factsVersions map the current Bazel binary writes, and
add a regression test pinning that an empty factsVersions map survives a
merge.

Fixes https://github.com/bazelbuild/bazel/issues/29742