### PR TITLE
Parallelize and flag-guard keeping change-prunable nodes in GC

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/AnalysisOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/AnalysisOptions.java
@@ -110,6 +110,19 @@ public abstract class AnalysisOptions extends OptionsBase {
   public abstract long getVersionWindowForDirtyNodeGc();
 
   @Option(
+      name = "experimental_keep_change_prunable_nodes_during_gc",
+      defaultValue = "false",
+      documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,
+      metadataTags = OptionMetadataTag.EXPERIMENTAL,
+      effectTags = {OptionEffectTag.HOST_MACHINE_RESOURCE_OPTIMIZATIONS},
+      help =
+          "If enabled, the dirty node garbage collection triggered by"
+              + " --version_window_for_dirty_node_gc keeps dirty nodes that change pruning would"
+              + " mark clean when they are next requested, at the cost of a scan over all dirty"
+              + " nodes at the end of the build.")
+  public abstract boolean getKeepChangePrunableNodesDuringGc();
+
+  @Option(
       name = "experimental_skyframe_cpu_heavy_skykeys_thread_pool_size",
       defaultValue = ResourceConverter.HOST_CPUS_KEYWORD,
       documentationCategory = OptionDocumentationCategory.UNDOCUMENTED,

--- a/src/main/java/com/google/devtools/build/lib/buildtool/BuildTool.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/BuildTool.java
@@ -426,7 +426,9 @@ public class BuildTool {
         // Delete dirty nodes to ensure that they do not accumulate indefinitely.
         long versionWindow = request.getViewOptions().getVersionWindowForDirtyNodeGc();
         if (versionWindow != -1) {
-          env.getSkyframeExecutor().deleteOldNodes(versionWindow);
+          env.getSkyframeExecutor()
+              .deleteOldNodes(
+                  versionWindow, request.getViewOptions().getKeepChangePrunableNodesDuringGc());
         }
         // The workspace status actions will not run with certain flags, or if an error occurs early
         // in the build. Ensure that build info is posted on every build.

--- a/src/main/java/com/google/devtools/build/lib/buildtool/PostAnalysisQueryProcessor.java
+++ b/src/main/java/com/google/devtools/build/lib/buildtool/PostAnalysisQueryProcessor.java
@@ -89,7 +89,8 @@ public abstract class PostAnalysisQueryProcessor<T> implements BuildTool.Analysi
     //  reproducible at the level of a single command. Either tolerate, or wipe the analysis graph
     //  beforehand if this option is specified, or add another option to wipe if desired
     //  (SkyframeExecutor#handleAnalysisInvalidatingChange should be sufficient).
-    env.getSkyframeExecutor().deleteOldNodes(/* versionWindowForDirtyGc= */ 0);
+    env.getSkyframeExecutor()
+        .deleteOldNodes(/* versionWindowForDirtyGc= */ 0, /* keepChangePrunableNodes= */ false);
     env.getSkyframeExecutor().applyInvalidation(env.getReporter());
     if (!env.getSkyframeExecutor().tracksStateForIncrementality()) {
       throw new ExitException(

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SequencedSkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SequencedSkyframeExecutor.java
@@ -798,11 +798,11 @@ public class SequencedSkyframeExecutor extends SkyframeExecutor {
   }
 
   @Override
-  public void deleteOldNodes(long versionWindowForDirtyGc) {
+  public void deleteOldNodes(long versionWindowForDirtyGc, boolean keepChangePrunableNodes) {
     // TODO(bazel-team): perhaps we should come up with a separate GC class dedicated to maintaining
     // value garbage. If we ever do so, this logic should be moved there.
     if (trackIncrementalState) {
-      memoizingEvaluator.deleteDirty(versionWindowForDirtyGc);
+      memoizingEvaluator.deleteDirty(versionWindowForDirtyGc, keepChangePrunableNodes);
     }
   }
 

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -3166,8 +3166,12 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
    * <p>Specifying a value N means, if the current version is V and a value was dirtied (and has
    * remained so) in version U, and U + N &lt;= V, then the value will be marked for deletion and
    * purged in version V+1.
+   *
+   * <p>If {@code keepChangePrunableNodes} is true, dirty values that change pruning would mark
+   * clean when they are next requested are exempt from deletion.
    */
-  public abstract void deleteOldNodes(long versionWindowForDirtyGc);
+  public abstract void deleteOldNodes(
+      long versionWindowForDirtyGc, boolean keepChangePrunableNodes);
 
   @Nullable
   public PackageProgressReceiver getPackageProgressReceiver() {

--- a/src/main/java/com/google/devtools/build/skyframe/AbstractInMemoryMemoizingEvaluator.java
+++ b/src/main/java/com/google/devtools/build/skyframe/AbstractInMemoryMemoizingEvaluator.java
@@ -253,20 +253,25 @@ public abstract class AbstractInMemoryMemoizingEvaluator implements MemoizingEva
   }
 
   @Override
-  public final void deleteDirty(long versionAgeLimit) {
+  public final void deleteDirty(long versionAgeLimit, boolean keepChangePrunableNodes) {
     checkArgument(versionAgeLimit >= 0, versionAgeLimit);
     Version threshold = IntVersion.of(lastGraphVersion.getVal() - versionAgeLimit);
     var graph = getInMemoryGraph();
 
     var dirtyKeys = progressReceiver.getUnenqueuedDirtyKeys();
-    long profilerStartNanos = Profiler.instance().nanoTimeMaybe();
-    var toKeep = new ChangePrunableNodesFinder(graph, dirtyKeys).find();
-    Profiler.instance()
-        .completeTask(
-            profilerStartNanos,
-            ProfilerTask.INFO,
-            "Resurrected %d out of %d dirty nodes during GC"
-                .formatted(toKeep.size(), dirtyKeys.size()));
+    ImmutableSet<SkyKey> toKeep;
+    if (keepChangePrunableNodes) {
+      long profilerStartNanos = Profiler.instance().nanoTimeMaybe();
+      toKeep = new ChangePrunableNodesFinder(graph, dirtyKeys).find();
+      Profiler.instance()
+          .completeTask(
+              profilerStartNanos,
+              ProfilerTask.INFO,
+              "Resurrected %d out of %d dirty nodes during GC"
+                  .formatted(toKeep.size(), dirtyKeys.size()));
+    } else {
+      toKeep = ImmutableSet.of();
+    }
 
     valuesToDelete.addAll(
         Sets.filter(
@@ -318,8 +323,6 @@ public abstract class AbstractInMemoryMemoizingEvaluator implements MemoizingEva
         return ImmutableSet.of();
       }
 
-      // To avoid contention and scheduling too many jobs for our #cpus, we start
-      // SCAN_THREAD_COUNT jobs, each scanning a chunk of the candidates.
       var executor =
           ForkJoinQuiescingExecutor.newBuilder()
               .withOwnershipOf(
@@ -328,8 +331,6 @@ public abstract class AbstractInMemoryMemoizingEvaluator implements MemoizingEva
       long listSize = candidateList.size();
       long numJobs = min(SCAN_THREAD_COUNT, listSize);
       for (long i = 0; i < numJobs; i++) {
-        // Use long multiplication to avoid possible overflow, as numJobs * listSize might be
-        // larger than max int.
         int startIndex = (int) ((i * listSize) / numJobs);
         int endIndex = (int) (((i + 1) * listSize) / numJobs);
         List<SkyKey> chunk = candidateList.subList(startIndex, endIndex);

--- a/src/main/java/com/google/devtools/build/skyframe/AbstractInMemoryMemoizingEvaluator.java
+++ b/src/main/java/com/google/devtools/build/skyframe/AbstractInMemoryMemoizingEvaluator.java
@@ -16,18 +16,21 @@ package com.google.devtools.build.skyframe;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Math.min;
 
 import com.google.common.base.Predicates;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.MultimapBuilder;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Multisets;
 import com.google.common.collect.Sets;
 import com.google.devtools.build.lib.concurrent.AbstractQueueVisitor;
+import com.google.devtools.build.lib.concurrent.ForkJoinQuiescingExecutor;
+import com.google.devtools.build.lib.concurrent.NamedForkJoinPool;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.profiler.AutoProfiler;
 import com.google.devtools.build.lib.profiler.GoogleAutoProfilerUtils;
@@ -41,21 +44,23 @@ import com.google.devtools.build.skyframe.InvalidatingNodeVisitor.DirtyingInvali
 import com.google.devtools.build.skyframe.InvalidatingNodeVisitor.InvalidationState;
 import com.google.devtools.build.skyframe.SkyframeGraphStatsEvent.EvaluationStats;
 import com.google.errorprone.annotations.ForOverride;
-import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.io.PrintStream;
 import java.time.Duration;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -255,7 +260,7 @@ public abstract class AbstractInMemoryMemoizingEvaluator implements MemoizingEva
 
     var dirtyKeys = progressReceiver.getUnenqueuedDirtyKeys();
     long profilerStartNanos = Profiler.instance().nanoTimeMaybe();
-    var toKeep = findChangePrunableNodes(graph, dirtyKeys);
+    var toKeep = new ChangePrunableNodesFinder(graph, dirtyKeys).find();
     Profiler.instance()
         .completeTask(
             profilerStartNanos,
@@ -277,66 +282,136 @@ public abstract class AbstractInMemoryMemoizingEvaluator implements MemoizingEva
   }
 
   /**
-   * Returns the dirty nodes that change pruning would verify clean if it ran, which it doesn't
-   * purely because these nodes weren't in scope for the current evaluation.
+   * Finds the dirty nodes that change pruning would verify clean if it ran, which it doesn't purely
+   * because these nodes weren't in scope for the current evaluation.
+   *
+   * <p>Operates in two phases: a parallel scan over all candidates that builds a DAG of dirty but
+   * unchanged deletion candidates and their dirty rdeps, followed by a traversal of the DAG that
+   * keeps all nodes whose dirty deps are also kept. The scan performs all graph accesses and its
+   * cost scales with the total number of candidates, so it runs on multiple threads; the traversal
+   * only visits the nodes that end up being kept.
    */
-  private static ImmutableSet<SkyKey> findChangePrunableNodes(
-      InMemoryGraph graph, Set<SkyKey> candidates) {
-    // The first step is to build a DAG of dirty but unchanged deletion candidates and their dirty
-    // rdeps.
-    var remainingDirtyDeps = new Object2IntOpenHashMap<SkyKey>();
-    var dirtyRdeps = MultimapBuilder.hashKeys().arrayListValues().<SkyKey, SkyKey>build();
-    var ready = new ArrayDeque<SkyKey>();
-    skipCandidate:
-    for (var skyKey : candidates) {
-      if (!(graph.getIfPresent(skyKey) instanceof IncrementalInMemoryNodeEntry entry)) {
-        continue;
-      }
-      Iterable<SkyKey> lastBuildDeps = entry.lastBuildDepsIfChangePrunable();
-      if (lastBuildDeps == null) {
-        continue;
-      }
-      Version lastEvaluated = entry.lastEvaluatedVersion();
-      var dirtyDeps = new ArrayList<SkyKey>();
-      for (var dep : lastBuildDeps) {
-        NodeEntry depEntry = graph.getIfPresent(dep);
-        // A dep must be present and unchanged since this node was last evaluated to be potentially
-        // change-prunable. Undone deps that aren't unenqueued dirty deps will never be considered
-        // below and thus make an entry not change-prunable.
-        if (depEntry == null || !depEntry.getVersion().atMost(lastEvaluated)) {
-          continue skipCandidate;
-        }
-        if (depEntry.isDone()) {
-          continue;
-        }
-        if (!candidates.contains(dep)) {
-          continue skipCandidate;
-        }
-        dirtyDeps.add(dep);
-      }
-      if (dirtyDeps.isEmpty()) {
-        ready.add(skyKey);
-      } else {
-        remainingDirtyDeps.addTo(skyKey, dirtyDeps.size());
-        for (var dirtyDep : dirtyDeps) {
-          dirtyRdeps.put(dirtyDep, skyKey);
-        }
-      }
+  private static final class ChangePrunableNodesFinder {
+    private static final int SCAN_THREAD_COUNT = Runtime.getRuntime().availableProcessors();
+
+    private final InMemoryGraph graph;
+    private final ImmutableSet<SkyKey> candidates;
+
+    // The DAG built by the scan phase: for each candidate with at least one dirty dep, the number
+    // of its dirty deps not yet known to be kept, together with the reverse edges. Candidates
+    // without dirty deps start out ready. Each entry in remainingDirtyDeps is written by a single
+    // scan thread, whereas dirtyRdeps values may receive edges from multiple threads.
+    private final ConcurrentHashMap<SkyKey, AtomicInteger> remainingDirtyDeps =
+        new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<SkyKey, ArrayList<SkyKey>> dirtyRdeps =
+        new ConcurrentHashMap<>();
+    private final ConcurrentLinkedQueue<SkyKey> ready = new ConcurrentLinkedQueue<>();
+
+    ChangePrunableNodesFinder(InMemoryGraph graph, ImmutableSet<SkyKey> candidates) {
+      this.graph = graph;
+      this.candidates = candidates;
     }
 
-    // Now visit the DAG, keeping all nodes whose dirty deps are also kept.
-    var toKeep = ImmutableSet.<SkyKey>builder();
-    SkyKey readyKey;
-    while ((readyKey = ready.poll()) != null) {
-      toKeep.add(readyKey);
-      for (var rdep : dirtyRdeps.get(readyKey)) {
-        if (remainingDirtyDeps.addTo(rdep, -1) == 1) {
-          // The last dirty dep of rdep is now known to be kept.
-          ready.add(rdep);
+    ImmutableSet<SkyKey> find() {
+      ImmutableList<SkyKey> candidateList = candidates.asList();
+      if (candidateList.isEmpty()) {
+        return ImmutableSet.of();
+      }
+
+      // To avoid contention and scheduling too many jobs for our #cpus, we start
+      // SCAN_THREAD_COUNT jobs, each scanning a chunk of the candidates.
+      var executor =
+          ForkJoinQuiescingExecutor.newBuilder()
+              .withOwnershipOf(
+                  NamedForkJoinPool.newNamedPool("find-change-prunable-nodes", SCAN_THREAD_COUNT))
+              .build();
+      long listSize = candidateList.size();
+      long numJobs = min(SCAN_THREAD_COUNT, listSize);
+      for (long i = 0; i < numJobs; i++) {
+        // Use long multiplication to avoid possible overflow, as numJobs * listSize might be
+        // larger than max int.
+        int startIndex = (int) ((i * listSize) / numJobs);
+        int endIndex = (int) (((i + 1) * listSize) / numJobs);
+        List<SkyKey> chunk = candidateList.subList(startIndex, endIndex);
+        executor.execute(() -> scanCandidates(chunk));
+      }
+      try {
+        executor.awaitQuiescence(/* interruptWorkers= */ true);
+      } catch (InterruptedException e) {
+        // Keeping no nodes is always safe, it merely GCs more aggressively.
+        Thread.currentThread().interrupt();
+        return ImmutableSet.of();
+      }
+
+      // Now visit the DAG, keeping all nodes whose dirty deps are also kept.
+      var toKeep = ImmutableSet.<SkyKey>builder();
+      SkyKey readyKey;
+      while ((readyKey = ready.poll()) != null) {
+        toKeep.add(readyKey);
+        var rdeps = dirtyRdeps.get(readyKey);
+        if (rdeps == null) {
+          continue;
+        }
+        for (var rdep : rdeps) {
+          if (remainingDirtyDeps.get(rdep).decrementAndGet() == 0) {
+            // The last dirty dep of rdep is now known to be kept.
+            ready.add(rdep);
+          }
+        }
+      }
+      return toKeep.build();
+    }
+
+    private void scanCandidates(List<SkyKey> chunk) {
+      skipCandidate:
+      for (var skyKey : chunk) {
+        if (Thread.currentThread().isInterrupted()) {
+          // A partial scan only ever results in fewer nodes being kept, which is always safe.
+          return;
+        }
+        if (!(graph.getIfPresent(skyKey) instanceof IncrementalInMemoryNodeEntry entry)) {
+          continue;
+        }
+        Iterable<SkyKey> lastBuildDeps = entry.lastBuildDepsIfChangePrunable();
+        if (lastBuildDeps == null) {
+          continue;
+        }
+        Version lastEvaluated = entry.lastEvaluatedVersion();
+        var dirtyDeps = new ArrayList<SkyKey>();
+        for (var dep : lastBuildDeps) {
+          NodeEntry depEntry = graph.getIfPresent(dep);
+          // A dep must be present and unchanged since this node was last evaluated to be
+          // potentially change-prunable. Undone deps that aren't unenqueued dirty deps will never
+          // be considered below and thus make an entry not change-prunable.
+          if (depEntry == null || !depEntry.getVersion().atMost(lastEvaluated)) {
+            continue skipCandidate;
+          }
+          if (depEntry.isDone()) {
+            continue;
+          }
+          if (!candidates.contains(dep)) {
+            continue skipCandidate;
+          }
+          dirtyDeps.add(dep);
+        }
+        if (dirtyDeps.isEmpty()) {
+          ready.add(skyKey);
+        } else {
+          remainingDirtyDeps.put(skyKey, new AtomicInteger(dirtyDeps.size()));
+          for (var dirtyDep : dirtyDeps) {
+            dirtyRdeps.compute(
+                dirtyDep,
+                (unusedKey, rdeps) -> {
+                  if (rdeps == null) {
+                    rdeps = new ArrayList<>();
+                  }
+                  rdeps.add(skyKey);
+                  return rdeps;
+                });
+          }
         }
       }
     }
-    return toKeep.build();
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/skyframe/BUILD
+++ b/src/main/java/com/google/devtools/build/skyframe/BUILD
@@ -95,7 +95,6 @@ java_library(
         "//src/main/java/com/google/devtools/common/options",
         "//third_party:auto_value",
         "//third_party:caffeine",
-        "//third_party:fastutil",
         "//third_party:flogger",
         "//third_party:guava",
         "//third_party:jsr305",

--- a/src/main/java/com/google/devtools/build/skyframe/MemoizingEvaluator.java
+++ b/src/main/java/com/google/devtools/build/skyframe/MemoizingEvaluator.java
@@ -79,8 +79,12 @@ public interface MemoizingEvaluator {
    * be recomputed and the new values stored in the cache again.
    *
    * <p>To delete all dirty values, you can specify 0 for the limit.
+   *
+   * <p>If {@code keepChangePrunableNodes} is true, dirty values that change pruning would mark
+   * clean when they are next requested are exempt from deletion, regardless of how long they have
+   * been dirty.
    */
-  void deleteDirty(long versionAgeLimit);
+  void deleteDirty(long versionAgeLimit, boolean keepChangePrunableNodes);
 
   /**
    * Returns the values in the graph.

--- a/src/test/java/com/google/devtools/build/skyframe/MemoizingEvaluatorTest.java
+++ b/src/test/java/com/google/devtools/build/skyframe/MemoizingEvaluatorTest.java
@@ -486,14 +486,14 @@ public abstract class MemoizingEvaluatorTest {
         .containsExactly(skyKey("top"), skyKey("d1"), d2Key, ErrorTransienceValue.KEY);
 
     String[] noKeys = {};
-    tester.evaluator.deleteDirty(2);
+    tester.evaluator.deleteDirty(2, /* keepChangePrunableNodes= */ false);
     tester.eval(true, noKeys);
 
     // The top node's value is dirty, but less than two generations old, so it wasn't deleted.
     assertThat(tester.evaluator.getValues().keySet())
         .containsExactly(skyKey("top"), skyKey("d1"), d2Key, ErrorTransienceValue.KEY);
 
-    tester.evaluator.deleteDirty(2);
+    tester.evaluator.deleteDirty(2, /* keepChangePrunableNodes= */ false);
     tester.eval(true, noKeys);
 
     // The top node's value was dirty, and was two generations old, so it was deleted.
@@ -510,7 +510,7 @@ public abstract class MemoizingEvaluatorTest {
 
     assertThat(tester.evalAndGet(/*keepGoing=*/ false, topKey)).isEqualTo(new StringValue("value"));
     failBuildAndRemoveValue(leafKey);
-    tester.evaluator.deleteDirty(0);
+    tester.evaluator.deleteDirty(0, /* keepChangePrunableNodes= */ false);
   }
 
   @Test
@@ -553,7 +553,7 @@ public abstract class MemoizingEvaluatorTest {
 
     // Run dirty-node GC with the smallest possible version window.
     String[] noKeys = {};
-    tester.evaluator.deleteDirty(0);
+    tester.evaluator.deleteDirty(0, /* keepChangePrunableNodes= */ true);
     tester.eval(/* keepGoing= */ false, noKeys);
 
     // d's only dep b change-pruned, so d is verifiable-clean and is kept rather than deleted.
@@ -565,6 +565,38 @@ public abstract class MemoizingEvaluatorTest {
     dEvaluated.set(false);
     assertThat(tester.evalAndGet(/* keepGoing= */ false, d)).isEqualTo(fixedB);
     assertThat(dEvaluated.get()).isFalse();
+  }
+
+  @Test
+  public void deleteDirtyDeletesChangePrunableNodeIfNotKeeping() throws Exception {
+    // Same setup as deleteDirtyKeepsChangePrunableNode, but without keepChangePrunableNodes, the
+    // dirty node d is deleted even though change pruning would verify it clean.
+    SkyKey a = nonHermeticKey("a");
+    SkyKey b = skyKey("b");
+    SkyKey c = skyKey("c");
+    SkyKey d = skyKey("d");
+    StringValue fixedB = new StringValue("fixed-b");
+
+    tester.set(a, new StringValue("a1"));
+    // b depends on a but always returns the same value, so it change-prunes when a changes.
+    tester.getOrCreate(b).setBuilder((skyKey, env) -> env.getValue(a) == null ? null : fixedB);
+    tester.getOrCreate(c).addDependency(b).setComputedValue(COPY);
+    tester.getOrCreate(d).addDependency(b).setComputedValue(COPY);
+
+    tester.eval(/* keepGoing= */ false, c, d);
+    assertThat(tester.evaluator.getValues().keySet()).containsAtLeast(a, b, c, d);
+
+    // Change a (b re-evaluates to the same value) and evaluate only c, leaving d dirty.
+    tester.set(a, new StringValue("a2"));
+    tester.invalidate();
+    tester.eval(/* keepGoing= */ false, c);
+    assertThat(tester.getDirtyKeys()).contains(d);
+
+    String[] noKeys = {};
+    tester.evaluator.deleteDirty(0, /* keepChangePrunableNodes= */ false);
+    tester.eval(/* keepGoing= */ false, noKeys);
+
+    assertThat(tester.evaluator.getValues().keySet()).doesNotContain(d);
   }
 
   @Test
@@ -608,7 +640,7 @@ public abstract class MemoizingEvaluatorTest {
 
     // Run dirty-node GC with the smallest possible version window.
     String[] noKeys = {};
-    tester.evaluator.deleteDirty(0);
+    tester.evaluator.deleteDirty(0, /* keepChangePrunableNodes= */ true);
     tester.eval(/* keepGoing= */ false, noKeys);
 
     // The whole chain is verifiable-clean, so both bPrime and (transitively) d are kept, not deleted.
@@ -646,7 +678,7 @@ public abstract class MemoizingEvaluatorTest {
     assertThat(tester.getDirtyKeys()).containsAtLeast(b, d);
 
     String[] noKeys = {};
-    tester.evaluator.deleteDirty(0);
+    tester.evaluator.deleteDirty(0, /* keepChangePrunableNodes= */ true);
     tester.eval(/* keepGoing= */ false, noKeys);
 
     // b needs a rebuild to discover that it would prune, so it (and its rdep d) are still GC'd.

--- a/src/test/shell/integration/loading_phase_test.sh
+++ b/src/test/shell/integration/loading_phase_test.sh
@@ -268,7 +268,8 @@ function test_unrelated_glob_change_pruned() {
     echo '[filegroup(name = "t%d" % i, srcs = glob(["data/*.txt"])) for i in range(21)]' \
         > "$pkg/BUILD"
 
-    bazel build "//$pkg:all" >& "$TEST_log" || fail "Expected initial build to succeed"
+    local -r gc_flag="--experimental_keep_change_prunable_nodes_during_gc"
+    bazel build "$gc_flag" "//$pkg:all" >& "$TEST_log" || fail "Expected initial build to succeed"
     local before="$(bazel dump --skyframe=count 2>/dev/null \
         | awk '/^CONFIGURED_TARGET/{print $2}')"
 
@@ -276,8 +277,8 @@ function test_unrelated_glob_change_pruned() {
     # build only one target (orphaning the other 20), then a no-op build to flush the dirty-node
     # GC's deferred deletions.
     echo unrelated > "$pkg/data/notes.md"
-    bazel build "//$pkg:t0" >& "$TEST_log" || fail "Expected build of t0 to succeed"
-    bazel build "//$pkg:t0" >& "$TEST_log" || fail "Expected flush build to succeed"
+    bazel build "$gc_flag" "//$pkg:t0" >& "$TEST_log" || fail "Expected build of t0 to succeed"
+    bazel build "$gc_flag" "//$pkg:t0" >& "$TEST_log" || fail "Expected flush build to succeed"
     local after="$(bazel dump --skyframe=count 2>/dev/null \
         | awk '/^CONFIGURED_TARGET/{print $2}')"
 


### PR DESCRIPTION
### Description

Implements the two changes requested in https://github.com/bazelbuild/bazel/pull/29965#issuecomment-4897494326 on top of the PR branch:

* **Parallelize the change-prune scan in `deleteDirty`.** The scan over all dirty deletion candidates performs all graph accesses and scales with the total number of dirty nodes, so it now runs on one job per CPU core over a `NamedForkJoinPool` wrapped in a `ForkJoinQuiescingExecutor`, following the chunking scheme of `InvalidatingNodeVisitor.DeletingNodeVisitor`. The scan jobs write into shared concurrent maps; the subsequent Kahn traversal of the DAG stays single-threaded since its cost only scales with the nodes that end up being kept. The result is identical to the single-threaded computation because the traversal is insensitive to the order in which edges were recorded. If the scan is interrupted, no nodes are kept, which is always safe as it only means more aggressive GC.

* **Gate the feature behind `--experimental_keep_change_prunable_nodes_during_gc` (default off).** The flag lives in `AnalysisOptions` next to `--version_window_for_dirty_node_gc` and is plumbed through `SkyframeExecutor#deleteOldNodes` to `MemoizingEvaluator#deleteDirty`. With the flag off, the scan is skipped entirely, restoring the previous GC behavior. `PostAnalysisQueryProcessor` always deletes dirty nodes since its cleanup exists to purge stale keys from the graph before querying it; kept change-prunable nodes would still be dirty and surface in rdeps.

### Motivation

Requested in review of #29965: `findChangePrunableNodes` took 139s single-threaded on a build with ~6M dirty keys.

### Build API Changes

Adds the undocumented, experimental flag `--experimental_keep_change_prunable_nodes_during_gc` (default off). No Starlark API changes.

### Checklist

- [x] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

### Release Notes

RELNOTES: None
