### PR TITLE
Intern StarlarkBuildSettingsDetailsValue.Key to fix memory regression

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -1223,7 +1223,6 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/concurrent:thread_safety",
         "//src/main/java/com/google/devtools/build/lib/packages",
         "//src/main/java/com/google/devtools/build/lib/skyframe:sky_functions",
-        "//src/main/java/com/google/devtools/build/lib/skyframe/serialization:visible-for-serialization",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec",
         "//src/main/java/com/google/devtools/build/skyframe:skyframe-objects",
         "//third_party:auto_value",

--- a/src/main/java/com/google/devtools/build/lib/analysis/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/BUILD
@@ -1223,6 +1223,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/concurrent:thread_safety",
         "//src/main/java/com/google/devtools/build/lib/packages",
         "//src/main/java/com/google/devtools/build/lib/skyframe:sky_functions",
+        "//src/main/java/com/google/devtools/build/lib/skyframe/serialization:visible-for-serialization",
         "//src/main/java/com/google/devtools/build/lib/skyframe/serialization/autocodec",
         "//src/main/java/com/google/devtools/build/skyframe:skyframe-objects",
         "//third_party:auto_value",

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -1083,13 +1083,7 @@ public abstract class CoreOptions extends FragmentOptions implements Cloneable {
                           .map(Map.Entry::getValue)
                           .collect(toImmutableSet()));
 
-  /**
-   * Returns the Starlark flags that {@code --flag_alias} maps to a {@code host_}-prefixed name.
-   *
-   * <p>These are needed to resolve the {@code exec:--host_foo} scope type, which propagates {@code
-   * --foo}'s exec value from {@code --host_foo}. The result is cached because it's recomputed for
-   * every configured target that applies the Starlark exec transition.
-   */
+  /** Returns the Starlark flags that {@code --flag_alias} maps to a {@code host_}-prefixed name. */
   public final ImmutableSet<Label> getHostFlagAliases() {
     return HOST_FLAG_ALIASES_CACHE.get(getCommandLineFlagAliasesMap());
   }

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/CoreOptions.java
@@ -16,12 +16,14 @@ package com.google.devtools.build.lib.analysis.config;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Map.Entry.comparingByKey;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
 import com.google.devtools.build.lib.analysis.config.CoreOptionConverters.LabelListConverter;
 import com.google.devtools.build.lib.analysis.config.CoreOptionConverters.LabelToStringEntryConverter;
@@ -1068,6 +1070,28 @@ public abstract class CoreOptions extends FragmentOptions implements Cloneable {
 
   public final ImmutableMap<String, Label> getCommandLineFlagAliasesMap() {
     return ALIAS_MAP_CACHE.get(getCommandLineFlagAliases());
+  }
+
+  private static final LoadingCache<ImmutableMap<String, Label>, ImmutableSet<Label>>
+      HOST_FLAG_ALIASES_CACHE =
+          Caffeine.newBuilder()
+              .weakKeys()
+              .build(
+                  aliases ->
+                      aliases.entrySet().stream()
+                          .filter(alias -> alias.getKey().startsWith("host_"))
+                          .map(Map.Entry::getValue)
+                          .collect(toImmutableSet()));
+
+  /**
+   * Returns the Starlark flags that {@code --flag_alias} maps to a {@code host_}-prefixed name.
+   *
+   * <p>These are needed to resolve the {@code exec:--host_foo} scope type, which propagates {@code
+   * --foo}'s exec value from {@code --host_foo}. The result is cached because it's recomputed for
+   * every configured target that applies the Starlark exec transition.
+   */
+  public final ImmutableSet<Label> getHostFlagAliases() {
+    return HOST_FLAG_ALIASES_CACHE.get(getCommandLineFlagAliasesMap());
   }
 
   /** Ways configured targets may provide the {@link Fragment}s they require. */

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/StarlarkExecTransitionLoader.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/StarlarkExecTransitionLoader.java
@@ -181,8 +181,6 @@ public final class StarlarkExecTransitionLoader {
   static class StarlarkExecTransitionProvider extends StarlarkAttributeTransitionProvider {
     @Nullable private final StarlarkBuildSettingsDetailsValue scopeDetails;
 
-    // Cached because a provider is created for every configured target and hashing scopeDetails
-    // walks all of its maps: ImmutableMap doesn't cache its own hash code.
     private final int hashCode;
 
     StarlarkExecTransitionProvider(

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/StarlarkExecTransitionLoader.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/StarlarkExecTransitionLoader.java
@@ -18,6 +18,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.common.base.Splitter;
 import com.google.common.base.Verify;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.devtools.build.lib.analysis.config.transitions.SplitTransition;
 import com.google.devtools.build.lib.analysis.starlark.StarlarkAttributeTransitionProvider;
@@ -137,20 +138,12 @@ public final class StarlarkExecTransitionLoader {
     // Load scope info for all Starlark build setting flags in the current config, filtering out
     // feature flags since they don't have scopes.
     StarlarkBuildSettingsDetailsValue scopeDetails = null;
-    Set<Label> starlarkFlags =
-        options.getStarlarkOptions().entrySet().stream()
-            .filter(e -> !(e.getValue() instanceof FeatureFlagValue))
-            .map(Map.Entry::getKey)
-            .collect(toImmutableSet());
+    ImmutableSet<Label> starlarkFlags = flagsWithScopes(options.getStarlarkOptions());
 
     // Look up the host flags declared by users in the blazerc/MODULE.bazel files with alias
     // pointing to the starlark definition. This is useful to determine exec propagation for flags
     // with scope that starts with "exec:--".
-    ImmutableSet<Label> hostFlags =
-        options.get(CoreOptions.class).getCommandLineFlagAliasesMap().entrySet().stream()
-            .filter(alias -> alias.getKey().startsWith("host_"))
-            .map(Map.Entry::getValue)
-            .collect(toImmutableSet());
+    ImmutableSet<Label> hostFlags = options.get(CoreOptions.class).getHostFlagAliases();
 
     if (!starlarkFlags.isEmpty() || !hostFlags.isEmpty()) {
       scopeDetails = detailsLoader.getValue(starlarkFlags, hostFlags);
@@ -164,15 +157,40 @@ public final class StarlarkExecTransitionLoader {
             (StarlarkDefinedConfigTransition) transition, scopeDetails));
   }
 
+  /**
+   * Returns the labels of the Starlark flags in {@code starlarkOptions} that can have scopes, i.e.
+   * all of them except feature flags.
+   *
+   * <p>This method is called once per configured target, so it avoids allocating a new set in the
+   * common case where no feature flags are set. Returning the map's cached key set also lets the
+   * {@link StarlarkBuildSettingsDetailsValue.Key} interner short-circuit on reference equality.
+   */
+  private static ImmutableSet<Label> flagsWithScopes(ImmutableMap<Label, Object> starlarkOptions) {
+    for (Object value : starlarkOptions.values()) {
+      if (value instanceof FeatureFlagValue) {
+        return starlarkOptions.entrySet().stream()
+            .filter(e -> !(e.getValue() instanceof FeatureFlagValue))
+            .map(Map.Entry::getKey)
+            .collect(toImmutableSet());
+      }
+    }
+    return starlarkOptions.keySet();
+  }
+
   /** A marker class to distinguish the exec transition from other starlark transitions. */
   static class StarlarkExecTransitionProvider extends StarlarkAttributeTransitionProvider {
     @Nullable private final StarlarkBuildSettingsDetailsValue scopeDetails;
+
+    // Cached because a provider is created for every configured target and hashing scopeDetails
+    // walks all of its maps: ImmutableMap doesn't cache its own hash code.
+    private final int hashCode;
 
     StarlarkExecTransitionProvider(
         StarlarkDefinedConfigTransition execTransition,
         @Nullable StarlarkBuildSettingsDetailsValue scopeDetails) {
       super(execTransition);
       this.scopeDetails = scopeDetails;
+      this.hashCode = Objects.hash(super.hashCode(), scopeDetails);
     }
 
     @Override
@@ -193,7 +211,7 @@ public final class StarlarkExecTransitionLoader {
 
     @Override
     public int hashCode() {
-      return Objects.hash(super.hashCode(), scopeDetails);
+      return hashCode;
     }
 
     @Override

--- a/src/main/java/com/google/devtools/build/lib/analysis/producers/TransitionApplier.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/producers/TransitionApplier.java
@@ -30,9 +30,7 @@ import com.google.devtools.build.lib.skyframe.config.BuildConfigurationKey;
 import com.google.devtools.build.lib.skyframe.config.BuildConfigurationKeyValue;
 import com.google.devtools.build.skyframe.SkyValue;
 import com.google.devtools.build.skyframe.state.StateMachine;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.annotation.Nullable;
 
@@ -124,26 +122,19 @@ final class TransitionApplier
         transitionCache.getAllStarlarkBuildSettings(
             transition,
             fromConfiguration.getOptions().get(CoreOptions.class).getCommandLineFlagAliasesMap());
-    Set<Label> hostFlags = new HashSet<>();
+    ImmutableSet<Label> hostFlags;
 
     // If the transition is the exec transition, we want to look up the host flag declared by
     // users in the blazerc/MODULE.bazel files with alias pointing to the starlark definition. This
     // is useful to determine exec propagation for flags with scope that starts with "exec:--".
     if (transition.getName().equals("exec")) {
-      for (Map.Entry<String, Label> alias :
-          fromConfiguration
-              .getOptions()
-              .get(CoreOptions.class)
-              .getCommandLineFlagAliasesMap()
-              .entrySet()) {
-        if (alias.getKey().startsWith("host_")) {
-          hostFlags.add(alias.getValue());
-        }
-      }
+      hostFlags = fromConfiguration.getOptions().get(CoreOptions.class).getHostFlagAliases();
     } else if (starlarkBuildSettings.isEmpty()) {
       // Quick escape if transition doesn't use any Starlark build settings.
       buildSettingsDetailsValue = StarlarkBuildSettingsDetailsValue.EMPTY;
       return applyStarlarkTransition(tasks);
+    } else {
+      hostFlags = ImmutableSet.of();
     }
     tasks.lookUp(
         StarlarkBuildSettingsDetailsValue.key(starlarkBuildSettings, hostFlags),

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkBuildSettingsDetailsValue.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkBuildSettingsDetailsValue.java
@@ -24,7 +24,6 @@ import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
 import com.google.devtools.build.lib.packages.Type;
 import com.google.devtools.build.lib.skyframe.SkyFunctions;
-import com.google.devtools.build.lib.skyframe.serialization.VisibleForSerialization;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.skyframe.SkyFunctionName;
 import com.google.devtools.build.skyframe.SkyKey;
@@ -150,35 +149,21 @@ public record StarlarkBuildSettingsDetailsValue(
   @Immutable
   @ThreadSafe
   @AutoCodec
-  public static final class Key implements SkyKey {
+  public record Key(ImmutableSet<Label> buildSettings, ImmutableSet<Label> hostFlags)
+      implements SkyKey {
     private static final SkyKeyInterner<Key> interner = SkyKey.newInterner();
 
-    private final ImmutableSet<Label> buildSettings;
-    private final ImmutableSet<Label> hostFlags;
-    private final int hashCode;
-
-    private Key(ImmutableSet<Label> buildSettings, ImmutableSet<Label> hostFlags) {
-      this.buildSettings = requireNonNull(buildSettings, "buildSettings");
-      this.hostFlags = requireNonNull(hostFlags, "hostFlags");
-      this.hashCode = 31 * buildSettings.hashCode() + hostFlags.hashCode();
+    public Key {
+      requireNonNull(buildSettings, "buildSettings");
+      requireNonNull(hostFlags, "hostFlags");
     }
 
+    // Doubles as the AutoCodec instantiator so that deserialized keys are interned too. Note that
+    // @AutoCodec.Interner can't be used here: it generates a codec that writes fields through
+    // Unsafe field offsets, which record components don't support.
+    @AutoCodec.Instantiator
     public static Key create(ImmutableSet<Label> buildSettings, ImmutableSet<Label> hostFlags) {
       return interner.intern(new Key(buildSettings, hostFlags));
-    }
-
-    @VisibleForSerialization
-    @AutoCodec.Interner
-    static Key intern(Key key) {
-      return interner.intern(key);
-    }
-
-    public ImmutableSet<Label> buildSettings() {
-      return buildSettings;
-    }
-
-    public ImmutableSet<Label> hostFlags() {
-      return hostFlags;
     }
 
     @Override
@@ -189,27 +174,6 @@ public record StarlarkBuildSettingsDetailsValue(
     @Override
     public SkyKeyInterner<Key> getSkyKeyInterner() {
       return interner;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-      if (obj == this) {
-        return true;
-      }
-      return obj instanceof Key other
-          && hashCode == other.hashCode
-          && buildSettings.equals(other.buildSettings)
-          && hostFlags.equals(other.hostFlags);
-    }
-
-    @Override
-    public int hashCode() {
-      return hashCode;
-    }
-
-    @Override
-    public String toString() {
-      return "Key[buildSettings=%s, hostFlags=%s]".formatted(buildSettings, hostFlags);
     }
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkBuildSettingsDetailsValue.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkBuildSettingsDetailsValue.java
@@ -138,13 +138,7 @@ public record StarlarkBuildSettingsDetailsValue(
       String flagScopeType,
       String hostFlagScopeType) {}
 
-  /**
-   * {@link SkyKey} implementation used for {@link StarlarkBuildSettingsDetailsValue}.
-   *
-   * <p>Instances are interned: the exec transition requests this key once per configured target and
-   * Skyframe retains the requesting key instance in each node's dependency list. Without interning,
-   * every configured target would retain its own copy of the (potentially large) label sets.
-   */
+  /** {@link SkyKey} implementation used for {@link StarlarkBuildSettingsDetailsValue}. */
   @CheckReturnValue
   @Immutable
   @ThreadSafe
@@ -158,9 +152,6 @@ public record StarlarkBuildSettingsDetailsValue(
       requireNonNull(hostFlags, "hostFlags");
     }
 
-    // Doubles as the AutoCodec instantiator so that deserialized keys are interned too. Note that
-    // @AutoCodec.Interner can't be used here: it generates a codec that writes fields through
-    // Unsafe field offsets, which record components don't support.
     @AutoCodec.Instantiator
     public static Key create(ImmutableSet<Label> buildSettings, ImmutableSet<Label> hostFlags) {
       return interner.intern(new Key(buildSettings, hostFlags));

--- a/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkBuildSettingsDetailsValue.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkBuildSettingsDetailsValue.java
@@ -24,9 +24,11 @@ import com.google.devtools.build.lib.concurrent.ThreadSafety.Immutable;
 import com.google.devtools.build.lib.concurrent.ThreadSafety.ThreadSafe;
 import com.google.devtools.build.lib.packages.Type;
 import com.google.devtools.build.lib.skyframe.SkyFunctions;
+import com.google.devtools.build.lib.skyframe.serialization.VisibleForSerialization;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
 import com.google.devtools.build.skyframe.SkyFunctionName;
 import com.google.devtools.build.skyframe.SkyKey;
+import com.google.devtools.build.skyframe.SkyKey.SkyKeyInterner;
 import com.google.devtools.build.skyframe.SkyValue;
 import com.google.errorprone.annotations.CheckReturnValue;
 import java.util.Map;
@@ -137,16 +139,46 @@ public record StarlarkBuildSettingsDetailsValue(
       String flagScopeType,
       String hostFlagScopeType) {}
 
-  /** {@link SkyKey} implementation used for {@link StarlarkBuildSettingsDetailsValue}. */
+  /**
+   * {@link SkyKey} implementation used for {@link StarlarkBuildSettingsDetailsValue}.
+   *
+   * <p>Instances are interned: the exec transition requests this key once per configured target and
+   * Skyframe retains the requesting key instance in each node's dependency list. Without interning,
+   * every configured target would retain its own copy of the (potentially large) label sets.
+   */
   @CheckReturnValue
   @Immutable
   @ThreadSafe
   @AutoCodec
-  public record Key(ImmutableSet<Label> buildSettings, ImmutableSet<Label> hostFlags)
-      implements SkyKey {
-    public Key {
-      requireNonNull(buildSettings, "buildSettings");
-      requireNonNull(hostFlags, "hostFlags");
+  public static final class Key implements SkyKey {
+    private static final SkyKeyInterner<Key> interner = SkyKey.newInterner();
+
+    private final ImmutableSet<Label> buildSettings;
+    private final ImmutableSet<Label> hostFlags;
+    private final int hashCode;
+
+    private Key(ImmutableSet<Label> buildSettings, ImmutableSet<Label> hostFlags) {
+      this.buildSettings = requireNonNull(buildSettings, "buildSettings");
+      this.hostFlags = requireNonNull(hostFlags, "hostFlags");
+      this.hashCode = 31 * buildSettings.hashCode() + hostFlags.hashCode();
+    }
+
+    public static Key create(ImmutableSet<Label> buildSettings, ImmutableSet<Label> hostFlags) {
+      return interner.intern(new Key(buildSettings, hostFlags));
+    }
+
+    @VisibleForSerialization
+    @AutoCodec.Interner
+    static Key intern(Key key) {
+      return interner.intern(key);
+    }
+
+    public ImmutableSet<Label> buildSettings() {
+      return buildSettings;
+    }
+
+    public ImmutableSet<Label> hostFlags() {
+      return hostFlags;
     }
 
     @Override
@@ -154,8 +186,30 @@ public record StarlarkBuildSettingsDetailsValue(
       return SkyFunctions.STARLARK_BUILD_SETTINGS_DETAILS;
     }
 
-    public static Key create(ImmutableSet<Label> buildSettings, ImmutableSet<Label> hostFlags) {
-      return new Key(buildSettings, hostFlags);
+    @Override
+    public SkyKeyInterner<Key> getSkyKeyInterner() {
+      return interner;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj == this) {
+        return true;
+      }
+      return obj instanceof Key other
+          && hashCode == other.hashCode
+          && buildSettings.equals(other.buildSettings)
+          && hostFlags.equals(other.hostFlags);
+    }
+
+    @Override
+    public int hashCode() {
+      return hashCode;
+    }
+
+    @Override
+    public String toString() {
+      return "Key[buildSettings=%s, hostFlags=%s]".formatted(buildSettings, hostFlags);
     }
   }
 }


### PR DESCRIPTION
### Description

Follow-up to the scope-extraction branch (bazelbuild/bazel#28574), addressing the analysis-phase regressions measured on a Java-heavy target.

**Memory (fixed, measured).** `StarlarkExecTransitionLoader.loadStarlarkExecTransition()` looks up a `StarlarkBuildSettingsDetailsValue` for all Starlark flags in the current config, and `DependencyResolver` / `AspectFunction` call it once per configured target and aspect. Skyframe retains the requesting key instance in every node's dependency list, and `StarlarkBuildSettingsDetailsValue.Key` had no interner, so each node kept its own copy of the key plus two `ImmutableSet<Label>` instances. Interning it moved memory from **+6.8% to −0.3%** against the same baseline — slightly better than before the branch, because `TransitionApplier` already requested the same un-interned key type on master.

**CPU / wall.** Interning fixed retention but not the edge itself, which is what the remaining commits target.

Commits:

1. **Intern `StarlarkBuildSettingsDetailsValue.Key`** (`SkyKeyInterner` + `getSkyKeyInterner()`), matching the pattern this branch already applies to `BuildOptionsScopeValue.Key`. `create()` is tagged `@AutoCodec.Instantiator` so deserialized keys are interned too — `@AutoCodec.Interner` can't be used, since it generates an `InterningObjectCodec` whose fields are addressed via `Unsafe.objectFieldOffset`, which throws `UnsupportedOperationException` for record components. Also stops rebuilding the key's components per configured target: `flagsWithScopes()` returns `getStarlarkOptions().keySet()` directly unless feature flags are set, and `CoreOptions.getHostFlagAliases()` caches the `host_`-prefixed alias set the way `getCommandLineFlagAliasesMap()` already does. `StarlarkExecTransitionProvider` caches its hash code, since hashing `scopeDetails` walks seven `ImmutableMap`s and (unlike `ImmutableSet`) `ImmutableMap` doesn't cache its own hash.

2. **Resolve the scope details once per configuration.** The value is a pure function of the configuration's Starlark flags, and there are far fewer configurations than targets, so `BuildConfigurationFunction` now resolves it and stores it on `BuildConfigurationValue`. `DependencyResolver`, `AspectFunction` and `SkyframeBuildView` read it from the configuration they already depend on, so invalidation still flows through the existing edge and no node accumulates a reverse dep per configured target. `StarlarkExecTransitionLoader.execScopeDetailsKey(BuildOptions)` is extracted so the key is computed identically in both places; the condition under which a key is needed is unchanged. `SkyframeExecutor` still evaluates through Skyframe — it has no configuration in hand.

3. **Stop minting a SkyKey per transitioned dependency edge.** `TransitionApplier` wrapped every transition result in a `BuildConfigurationKeyValue.Key` that `BuildConfigurationKeyMapProducer` immediately unpacked into build options and a `forBaseline` flag. The key was never looked up in Skyframe on that path — it was a two-field parameter carrier — but creating one still costs a `SkyKeyInterner.intern` per edge, routed through `PooledInterner` into the graph's node map during evaluation. The two values are now passed explicitly. Also switches `BuildConfigurationKeyValue.Key.hashCode` from `Objects.hash` to `HashCodes.hashObjects` to drop the varargs array (the boolean autoboxes to a cached `Boolean`, so the existing two-argument overload suffices and the hash values are unchanged).

### Motivation

Bring the branch's analysis-phase memory and CPU back in line before it lands. See the benchmark numbers on bazelbuild/bazel#28574.

Not addressed here, but worth a look: `FunctionSplitTransition.equals`/`hashCode` ignore `scopeDetails` while `split()` uses it. That appears safe today because `scopeDetails` is a deterministic function of the config's Starlark flags and `StarlarkTransitionCache.Key` includes `fromOptions`, but it silently becomes a wrong-result bug if the details ever stop being derived purely from `fromOptions`, so it may deserve a comment.

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

Two things to check with a real build, since this was developed without a Bazel toolchain and is reviewed and javac-syntax-checked but **not compiled or tested**:

- `BuildConfigurationValue` is `@AutoCodec` with a sole constructor, so the new parameter is serialized into every config. Configs are few, so the size cost should be negligible, but the serialized form does change.
- `analysis/config:build_configuration` now depends on `analysis:starlark/starlark_build_settings_details_value`. The reverse direction looks clear (that target's deps are `analysis/config:scope`, `cmdline`, `packages`, `sky_functions`, `autocodec`, none of which reach `build_configuration`), but only a real build rules out a cycle.

### Release Notes

RELNOTES: None