### PR TITLE
Stop doing per-target and per-edge Skyframe work in the exec transition path

### DIFF
--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BUILD
@@ -69,6 +69,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/actions:commandline_limits",
         "//src/main/java/com/google/devtools/build/lib/analysis:blaze_directories",
         "//src/main/java/com/google/devtools/build/lib/analysis:platform_options",
+        "//src/main/java/com/google/devtools/build/lib/analysis:starlark/starlark_build_settings_details_value",
         "//src/main/java/com/google/devtools/build/lib/analysis:test/test_configuration",
         "//src/main/java/com/google/devtools/build/lib/buildeventstream",
         "//src/main/java/com/google/devtools/build/lib/buildeventstream/proto:build_event_stream_java_proto",

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/BuildConfigurationValue.java
@@ -28,6 +28,7 @@ import com.google.devtools.build.lib.actions.BuildConfigurationEvent;
 import com.google.devtools.build.lib.actions.CommandLineLimits;
 import com.google.devtools.build.lib.analysis.BlazeDirectories;
 import com.google.devtools.build.lib.analysis.PlatformOptions;
+import com.google.devtools.build.lib.analysis.starlark.StarlarkBuildSettingsDetailsValue;
 import com.google.devtools.build.lib.analysis.test.TestConfiguration.TestOptions;
 import com.google.devtools.build.lib.buildeventstream.BuildEvent;
 import com.google.devtools.build.lib.buildeventstream.BuildEventIdUtil;
@@ -121,6 +122,16 @@ public class BuildConfigurationValue
   private final BuildOptions buildOptions;
   private final CoreOptions options;
 
+  /**
+   * Scope info for this configuration's Starlark build settings, needed by the Starlark exec
+   * transition. Null if this build uses the native exec transition or sets no Starlark flags.
+   *
+   * <p>Resolved once per configuration rather than once per configured target: see {@code
+   * StarlarkExecTransitionLoader.BuildSettingsDetailsLoader}. Not part of {@link #equals}: it's a
+   * pure function of the build options.
+   */
+  @Nullable private final StarlarkBuildSettingsDetailsValue starlarkExecScopeDetails;
+
   /** The cpu value based on the platform the configuration is built for. */
   private final String platformCpu;
 
@@ -197,6 +208,7 @@ public class BuildConfigurationValue
       @Nullable BuildOptions baselineOptions,
       boolean siblingRepositoryLayout,
       String platformCpu,
+      @Nullable StarlarkBuildSettingsDetailsValue starlarkExecScopeDetails,
       // Arguments below this are server-global.
       BlazeDirectories directories,
       GlobalStateProvider globalProvider,
@@ -218,6 +230,7 @@ public class BuildConfigurationValue
         mnemonic,
         siblingRepositoryLayout,
         platformCpu,
+        starlarkExecScopeDetails,
         globalProvider.getRunfilesPrefix(),
         directories,
         fragments,
@@ -251,6 +264,7 @@ public class BuildConfigurationValue
         mnemonic,
         siblingRepositoryLayout,
         "",
+        /* starlarkExecScopeDetails= */ null,
         globalProvider.getRunfilesPrefix(),
         directories,
         fragments,
@@ -278,6 +292,7 @@ public class BuildConfigurationValue
       String mnemonic,
       boolean siblingRepositoryLayout,
       String platformCpu,
+      @Nullable StarlarkBuildSettingsDetailsValue starlarkExecScopeDetails,
       // Arguments below this are either server-global and constant or completely dependent values.
       String workspaceName,
       BlazeDirectories directories,
@@ -289,6 +304,7 @@ public class BuildConfigurationValue
             ImmutableSortedMap.copyOf(fragments, FragmentClassSet.LEXICAL_FRAGMENT_SORTER));
     this.starlarkVisibleFragments = buildIndexOfStarlarkVisibleFragments();
     this.buildOptions = buildOptions;
+    this.starlarkExecScopeDetails = starlarkExecScopeDetails;
     this.mnemonic = mnemonic;
     this.options = buildOptions.get(CoreOptions.class);
     this.outputDirectories =
@@ -332,6 +348,15 @@ public class BuildConfigurationValue
     this.reservedActionMnemonics = reservedActionMnemonics;
     this.commandLineLimits = new CommandLineLimits(options.getMinParamFileSize());
     this.defaultFeatures = FeatureSet.parse(options.getDefaultFeatures());
+  }
+
+  /**
+   * Returns scope info for this configuration's Starlark build settings, or null if the Starlark
+   * exec transition needs none.
+   */
+  @Nullable
+  public StarlarkBuildSettingsDetailsValue starlarkExecScopeDetails() {
+    return starlarkExecScopeDetails;
   }
 
   @Override

--- a/src/main/java/com/google/devtools/build/lib/analysis/config/StarlarkExecTransitionLoader.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/config/StarlarkExecTransitionLoader.java
@@ -34,7 +34,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -73,12 +72,44 @@ public final class StarlarkExecTransitionLoader {
   /** Caller-provided logic for loading {@link StarlarkBuildSettingsDetailsValue}. */
   public interface BuildSettingsDetailsLoader {
     /**
-     * Loads scope info for the given build settings. Returns null if not all Skyframe deps are
+     * Loads the scope info identified by {@code key}. Returns null if not all Skyframe deps are
      * ready.
+     *
+     * <p>Callers that already hold the {@code BuildConfigurationValue} for the options passed to
+     * {@link #loadStarlarkExecTransition} should answer from {@code
+     * BuildConfigurationValue.starlarkExecScopeDetails()} instead of asking Skyframe: this method
+     * is called once per configured target, and requesting the value from Skyframe here makes every
+     * configured target a reverse dep of a single node.
      */
     @Nullable
-    StarlarkBuildSettingsDetailsValue getValue(Set<Label> buildSettings, Set<Label> hostFlags)
+    StarlarkBuildSettingsDetailsValue getValue(StarlarkBuildSettingsDetailsValue.Key key)
         throws InterruptedException, StarlarkExecTransitionLoadingException;
+  }
+
+  /**
+   * Returns the key for the scope info the Starlark exec transition needs to transition {@code
+   * options}, or null if it needs none.
+   *
+   * <p>{@code BuildConfigurationFunction} uses this to resolve the value once per configuration and
+   * store it on the {@code BuildConfigurationValue}, so that the exec transition can read it from
+   * the configuration rather than requesting it once per configured target.
+   */
+  @Nullable
+  public static StarlarkBuildSettingsDetailsValue.Key execScopeDetailsKey(BuildOptions options) {
+    CoreOptions coreOptions = options.get(CoreOptions.class);
+    if (coreOptions == null || coreOptions.getStarlarkExecConfig() == null) {
+      // The exec transition is implemented by native logic, which doesn't consult scopes.
+      return null;
+    }
+    // All Starlark build setting flags in the config, minus feature flags, which have no scopes.
+    ImmutableSet<Label> starlarkFlags = flagsWithScopes(options.getStarlarkOptions());
+    // Host flags declared by users in the blazerc/MODULE.bazel files with an alias pointing to the
+    // Starlark definition. These determine exec propagation for flags scoped "exec:--".
+    ImmutableSet<Label> hostFlags = coreOptions.getHostFlagAliases();
+    if (starlarkFlags.isEmpty() && hostFlags.isEmpty()) {
+      return null;
+    }
+    return StarlarkBuildSettingsDetailsValue.Key.create(starlarkFlags, hostFlags);
   }
 
   /**
@@ -135,18 +166,10 @@ public final class StarlarkExecTransitionLoader {
           flagName, userRef, parsedRef.starlarkSymbolName() + " is not a Starlark transition");
     }
 
-    // Load scope info for all Starlark build setting flags in the current config, filtering out
-    // feature flags since they don't have scopes.
     StarlarkBuildSettingsDetailsValue scopeDetails = null;
-    ImmutableSet<Label> starlarkFlags = flagsWithScopes(options.getStarlarkOptions());
-
-    // Look up the host flags declared by users in the blazerc/MODULE.bazel files with alias
-    // pointing to the starlark definition. This is useful to determine exec propagation for flags
-    // with scope that starts with "exec:--".
-    ImmutableSet<Label> hostFlags = options.get(CoreOptions.class).getHostFlagAliases();
-
-    if (!starlarkFlags.isEmpty() || !hostFlags.isEmpty()) {
-      scopeDetails = detailsLoader.getValue(starlarkFlags, hostFlags);
+    StarlarkBuildSettingsDetailsValue.Key scopeDetailsKey = execScopeDetailsKey(options);
+    if (scopeDetailsKey != null) {
+      scopeDetails = detailsLoader.getValue(scopeDetailsKey);
       if (scopeDetails == null) {
         return null;
       }

--- a/src/main/java/com/google/devtools/build/lib/analysis/producers/BuildConfigurationKeyMapProducer.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/producers/BuildConfigurationKeyMapProducer.java
@@ -15,10 +15,10 @@ package com.google.devtools.build.lib.analysis.producers;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import com.google.devtools.build.lib.analysis.config.BuildOptions;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.skyframe.BuildOptionsScopeFunction.BuildOptionsScopeFunctionException;
 import com.google.devtools.build.lib.skyframe.config.BuildConfigurationKey;
-import com.google.devtools.build.lib.skyframe.config.BuildConfigurationKeyValue;
 import com.google.devtools.build.lib.skyframe.config.PlatformMappingException;
 import com.google.devtools.build.lib.skyframe.toolchains.PlatformLookupUtil.InvalidPlatformException;
 import com.google.devtools.build.skyframe.state.StateMachine;
@@ -53,7 +53,8 @@ public class BuildConfigurationKeyMapProducer
   // -------------------- Input --------------------
   private final ResultSink sink;
   private final StateMachine runAfter;
-  private final Map<String, BuildConfigurationKeyValue.Key> options;
+  private final Map<String, BuildOptions> options;
+  private final boolean forBaseline;
   private final Label label;
 
   // -------------------- Internal State --------------------
@@ -62,11 +63,13 @@ public class BuildConfigurationKeyMapProducer
   public BuildConfigurationKeyMapProducer(
       ResultSink sink,
       StateMachine runAfter,
-      Map<String, BuildConfigurationKeyValue.Key> options,
+      Map<String, BuildOptions> options,
+      boolean forBaseline,
       Label label) {
     this.sink = sink;
     this.runAfter = runAfter;
     this.options = options;
+    this.forBaseline = forBaseline;
     this.results = Maps.newHashMapWithExpectedSize(options.size());
     this.label = label;
   }
@@ -81,6 +84,7 @@ public class BuildConfigurationKeyMapProducer
                     StateMachine.DONE,
                     context,
                     buildOptions,
+                    forBaseline,
                     label)));
     return this::combineResults;
   }

--- a/src/main/java/com/google/devtools/build/lib/analysis/producers/BuildConfigurationKeyProducer.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/producers/BuildConfigurationKeyProducer.java
@@ -26,7 +26,6 @@ import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.skyframe.BuildOptionsScopeFunction.BuildOptionsScopeFunctionException;
 import com.google.devtools.build.lib.skyframe.BuildOptionsScopeValue;
 import com.google.devtools.build.lib.skyframe.config.BuildConfigurationKey;
-import com.google.devtools.build.lib.skyframe.config.BuildConfigurationKeyValue;
 import com.google.devtools.build.lib.skyframe.config.ParsedFlagsValue;
 import com.google.devtools.build.lib.skyframe.config.PlatformMappingException;
 import com.google.devtools.build.lib.skyframe.config.PlatformMappingValue;
@@ -115,13 +114,14 @@ public final class BuildConfigurationKeyProducer<C>
       ResultSink<C> sink,
       StateMachine runAfter,
       C context,
-      BuildConfigurationKeyValue.Key key,
+      BuildOptions options,
+      boolean forBaseline,
       Label label) {
     this.sink = sink;
     this.runAfter = runAfter;
     this.context = context;
-    this.options = key.buildOptions();
-    this.forBaseline = key.forBaseline();
+    this.options = options;
+    this.forBaseline = forBaseline;
     this.label = label;
   }
 

--- a/src/main/java/com/google/devtools/build/lib/analysis/producers/TransitionApplier.java
+++ b/src/main/java/com/google/devtools/build/lib/analysis/producers/TransitionApplier.java
@@ -14,7 +14,6 @@
 package com.google.devtools.build.lib.analysis.producers;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
 import com.google.devtools.build.lib.analysis.config.BuildOptions;
 import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.analysis.config.StarlarkTransitionCache;
@@ -27,7 +26,6 @@ import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.events.ExtendedEventHandler;
 import com.google.devtools.build.lib.skyframe.PrecomputedValue;
 import com.google.devtools.build.lib.skyframe.config.BuildConfigurationKey;
-import com.google.devtools.build.lib.skyframe.config.BuildConfigurationKeyValue;
 import com.google.devtools.build.skyframe.SkyValue;
 import com.google.devtools.build.skyframe.state.StateMachine;
 import java.util.Map;
@@ -100,11 +98,9 @@ final class TransitionApplier
       return new BuildConfigurationKeyMapProducer(
           this.sink,
           this.runAfter,
-          Maps.transformValues(
-              transition.apply(
-                  TransitionUtil.restrict(transition, fromConfiguration.getOptions()),
-                  eventHandler),
-              BuildConfigurationKeyValue.Key::create),
+          transition.apply(
+              TransitionUtil.restrict(transition, fromConfiguration.getOptions()), eventHandler),
+          /* forBaseline= */ false,
           this.label);
     }
     if (stampDependent.get()
@@ -176,9 +172,6 @@ final class TransitionApplier
     }
 
     return new BuildConfigurationKeyMapProducer(
-        this.sink,
-        this.runAfter,
-        Maps.transformValues(transitionedOptions, BuildConfigurationKeyValue.Key::create),
-        this.label);
+        this.sink, this.runAfter, transitionedOptions, /* forBaseline= */ false, this.label);
   }
 }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/AspectFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/AspectFunction.java
@@ -58,7 +58,6 @@ import com.google.devtools.build.lib.analysis.producers.DependencyContextProduce
 import com.google.devtools.build.lib.analysis.producers.UnloadedToolchainContextsInputs;
 import com.google.devtools.build.lib.analysis.producers.UnloadedToolchainContextsProducer;
 import com.google.devtools.build.lib.analysis.starlark.StarlarkAttributeTransitionProvider;
-import com.google.devtools.build.lib.analysis.starlark.StarlarkBuildSettingsDetailsValue;
 import com.google.devtools.build.lib.bugreport.BugReport;
 import com.google.devtools.build.lib.causes.Cause;
 import com.google.devtools.build.lib.causes.LabelCause;
@@ -418,10 +417,10 @@ final class AspectFunction implements SkyFunction {
                     : targetAndConfiguration.getConfiguration().getOptions(),
                 (bzlKey) ->
                     (BzlLoadValue) env.getValueOrThrow(bzlKey, BzlLoadFailedException.class),
-                (buildSettings, hostFlags) -> {
-                  var detailsKey = StarlarkBuildSettingsDetailsValue.key(buildSettings, hostFlags);
-                  return (StarlarkBuildSettingsDetailsValue) env.getValue(detailsKey);
-                });
+                // Already resolved once per configuration by BuildConfigurationFunction; requesting
+                // it from Skyframe here would make every aspect a reverse dep of it.
+                unusedKey ->
+                    targetAndConfiguration.getConfiguration().starlarkExecScopeDetails());
         if (starlarkExecTransition == null) {
           return null; // Need Skyframe deps.
         }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/DependencyResolver.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/DependencyResolver.java
@@ -62,7 +62,6 @@ import com.google.devtools.build.lib.analysis.producers.MissingEdgeError;
 import com.google.devtools.build.lib.analysis.producers.PrerequisiteParameters;
 import com.google.devtools.build.lib.analysis.producers.UnloadedToolchainContextsInputs;
 import com.google.devtools.build.lib.analysis.starlark.StarlarkAttributeTransitionProvider;
-import com.google.devtools.build.lib.analysis.starlark.StarlarkBuildSettingsDetailsValue;
 import com.google.devtools.build.lib.analysis.starlark.StarlarkTransition.TransitionException;
 import com.google.devtools.build.lib.causes.AnalysisFailedCause;
 import com.google.devtools.build.lib.causes.Cause;
@@ -410,10 +409,9 @@ public final class DependencyResolver {
                   ? null
                   : targetAndConfiguration.getConfiguration().getOptions(),
               (bzlKey) -> (BzlLoadValue) env.getValueOrThrow(bzlKey, BzlLoadFailedException.class),
-              (buildSettings, hostFlags) -> {
-                var key = StarlarkBuildSettingsDetailsValue.key(buildSettings, hostFlags);
-                return (StarlarkBuildSettingsDetailsValue) env.getValue(key);
-              });
+              // Already resolved once per configuration by BuildConfigurationFunction; requesting
+              // it from Skyframe here would make every configured target a reverse dep of it.
+              unusedKey -> targetAndConfiguration.getConfiguration().starlarkExecScopeDetails());
       if (starlarkExecTransition == null) {
         return false;
       }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeBuildView.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeBuildView.java
@@ -71,7 +71,6 @@ import com.google.devtools.build.lib.analysis.config.ConfigConditions;
 import com.google.devtools.build.lib.analysis.config.InvalidConfigurationException;
 import com.google.devtools.build.lib.analysis.config.OptionsDiff;
 import com.google.devtools.build.lib.analysis.config.StarlarkExecTransitionLoader;
-import com.google.devtools.build.lib.analysis.starlark.StarlarkBuildSettingsDetailsValue;
 import com.google.devtools.build.lib.analysis.config.StarlarkExecTransitionLoader.StarlarkExecTransitionLoadingException;
 import com.google.devtools.build.lib.analysis.config.StarlarkTransitionCache;
 import com.google.devtools.build.lib.analysis.starlark.StarlarkAttributeTransitionProvider;
@@ -1396,11 +1395,9 @@ public final class SkyframeBuildView {
                     analysisEnvironment
                         .getSkyframeEnv()
                         .getValueOrThrow(bzlKey, BzlLoadFailedException.class),
-            (buildSettings, hostFlags) -> {
-              var detailsKey = StarlarkBuildSettingsDetailsValue.key(buildSettings, hostFlags);
-              return (StarlarkBuildSettingsDetailsValue)
-                  analysisEnvironment.getSkyframeEnv().getValue(detailsKey);
-            });
+            // Already resolved once per configuration by BuildConfigurationFunction; requesting it
+            // from Skyframe here would make every configured target a reverse dep of it.
+            unusedKey -> configuration.starlarkExecScopeDetails());
     if (starlarkExecTransition == null) {
       return null;
     }

--- a/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/SkyframeExecutor.java
@@ -2275,8 +2275,7 @@ public abstract class SkyframeExecutor implements WalkableGraphFactory {
               }
               return (BzlLoadValue) result.get(bzlKey);
             },
-            (buildSettings, hostFlags) -> {
-              SkyKey detailsKey = StarlarkBuildSettingsDetailsValue.key(buildSettings, hostFlags);
+            detailsKey -> {
               EvaluationResult<SkyValue> result =
                   evaluate(
                       ImmutableList.of(detailsKey),

--- a/src/main/java/com/google/devtools/build/lib/skyframe/config/BUILD
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/config/BUILD
@@ -31,6 +31,7 @@ java_library(
         "//src/main/java/com/google/devtools/build/lib/analysis:blaze_directories",
         "//src/main/java/com/google/devtools/build/lib/analysis:constraints/constraint_constants",
         "//src/main/java/com/google/devtools/build/lib/analysis:platform_options",
+        "//src/main/java/com/google/devtools/build/lib/analysis:starlark/starlark_build_settings_details_value",
         "//src/main/java/com/google/devtools/build/lib/analysis:test/test_configuration",
         "//src/main/java/com/google/devtools/build/lib/analysis:test/test_trimming_logic",
         "//src/main/java/com/google/devtools/build/lib/analysis/config:build_configuration",

--- a/src/main/java/com/google/devtools/build/lib/skyframe/config/BuildConfigurationFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/config/BuildConfigurationFunction.java
@@ -24,9 +24,11 @@ import com.google.devtools.build.lib.analysis.config.ConfigurationValueEvent;
 import com.google.devtools.build.lib.analysis.config.CoreOptions;
 import com.google.devtools.build.lib.analysis.config.FragmentFactory;
 import com.google.devtools.build.lib.analysis.config.InvalidConfigurationException;
+import com.google.devtools.build.lib.analysis.config.StarlarkExecTransitionLoader;
 import com.google.devtools.build.lib.analysis.config.StarlarkExecTransitionLoader.StarlarkExecTransitionLoadingException;
 import com.google.devtools.build.lib.analysis.config.transitions.BaselineOptionsValue;
 import com.google.devtools.build.lib.analysis.platform.PlatformValue;
+import com.google.devtools.build.lib.analysis.starlark.StarlarkBuildSettingsDetailsValue;
 import com.google.devtools.build.lib.analysis.test.TestConfiguration;
 import com.google.devtools.build.lib.cmdline.Label;
 import com.google.devtools.build.lib.packages.RuleClassProvider;
@@ -74,6 +76,18 @@ public final class BuildConfigurationFunction implements SkyFunction {
       return null;
     }
 
+    // Resolved here, once per configuration, so that the Starlark exec transition can read it off
+    // the configuration instead of requesting it once per configured target.
+    StarlarkBuildSettingsDetailsValue starlarkExecScopeDetails = null;
+    StarlarkBuildSettingsDetailsValue.Key scopeDetailsKey =
+        StarlarkExecTransitionLoader.execScopeDetailsKey(targetOptions);
+    if (scopeDetailsKey != null) {
+      starlarkExecScopeDetails = (StarlarkBuildSettingsDetailsValue) env.getValue(scopeDetailsKey);
+      if (starlarkExecScopeDetails == null) {
+        return null;
+      }
+    }
+
     try {
       var configurationValue =
           BuildConfigurationValue.create(
@@ -82,6 +96,7 @@ public final class BuildConfigurationFunction implements SkyFunction {
               starlarkSemantics.getBool(
                   BuildLanguageOptions.EXPERIMENTAL_SIBLING_REPOSITORY_LAYOUT),
               platformCpu,
+              starlarkExecScopeDetails,
               // Arguments below this are server-global.
               directories,
               ruleClassProvider,

--- a/src/main/java/com/google/devtools/build/lib/skyframe/config/BuildConfigurationKeyFunction.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/config/BuildConfigurationKeyFunction.java
@@ -49,7 +49,8 @@ public final class BuildConfigurationKeyFunction implements SkyFunction {
             new BuildConfigurationKeyMapProducer(
                 sink,
                 /* runAfter= */ StateMachine.DONE,
-                ImmutableMap.of(BUILD_OPTIONS_MAP_SINGLETON_KEY, key),
+                ImmutableMap.of(BUILD_OPTIONS_MAP_SINGLETON_KEY, key.buildOptions()),
+                key.forBaseline(),
                 null));
 
     boolean complete = driver.drive(env);

--- a/src/main/java/com/google/devtools/build/lib/skyframe/config/BuildConfigurationKeyValue.java
+++ b/src/main/java/com/google/devtools/build/lib/skyframe/config/BuildConfigurationKeyValue.java
@@ -19,6 +19,7 @@ import com.google.devtools.build.lib.concurrent.ThreadSafety;
 import com.google.devtools.build.lib.skyframe.SkyFunctions;
 import com.google.devtools.build.lib.skyframe.serialization.VisibleForSerialization;
 import com.google.devtools.build.lib.skyframe.serialization.autocodec.AutoCodec;
+import com.google.devtools.build.lib.util.HashCodes;
 import com.google.devtools.build.skyframe.SkyFunctionName;
 import com.google.devtools.build.skyframe.SkyKey;
 import com.google.devtools.build.skyframe.SkyValue;
@@ -81,7 +82,7 @@ public final class BuildConfigurationKeyValue implements SkyValue {
 
     @Override
     public int hashCode() {
-      return Objects.hash(buildOptions, forBaseline());
+      return HashCodes.hashObjects(buildOptions, forBaseline());
     }
 
     @Override

--- a/src/test/java/com/google/devtools/build/lib/analysis/producers/BuildConfigurationKeyMapProducerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/producers/BuildConfigurationKeyMapProducerTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Ordering;
 import com.google.devtools.build.lib.analysis.ConfiguredRuleClassProvider;
 import com.google.devtools.build.lib.analysis.config.BuildOptions;
@@ -27,7 +26,6 @@ import com.google.devtools.build.lib.analysis.config.FragmentOptions;
 import com.google.devtools.build.lib.analysis.config.RequiresOptions;
 import com.google.devtools.build.lib.skyframe.BuildOptionsScopeFunction.BuildOptionsScopeFunctionException;
 import com.google.devtools.build.lib.skyframe.config.BuildConfigurationKey;
-import com.google.devtools.build.lib.skyframe.config.BuildConfigurationKeyValue;
 import com.google.devtools.build.lib.skyframe.config.PlatformMappingException;
 import com.google.devtools.build.lib.skyframe.toolchains.PlatformLookupUtil.InvalidPlatformException;
 import com.google.devtools.build.lib.testutil.TestRuleClassProvider;
@@ -349,10 +347,7 @@ public class BuildConfigurationKeyMapProducerTest extends ProducerTestCase {
     Sink sink = new Sink();
     BuildConfigurationKeyMapProducer producer =
         new BuildConfigurationKeyMapProducer(
-            sink,
-            StateMachine.DONE,
-            Maps.transformValues(options, BuildConfigurationKeyValue.Key::create),
-            null);
+            sink, StateMachine.DONE, options, /* forBaseline= */ false, null);
     // Ignore the return value: sink will either return a result or re-throw whatever exception it
     // received from the producer.
     var unused = executeProducer(producer);

--- a/src/test/java/com/google/devtools/build/lib/analysis/producers/BuildConfigurationKeyProducerTest.java
+++ b/src/test/java/com/google/devtools/build/lib/analysis/producers/BuildConfigurationKeyProducerTest.java
@@ -31,7 +31,6 @@ import com.google.devtools.build.lib.skyframe.PrecomputedValue;
 import com.google.devtools.build.lib.skyframe.SequencedSkyframeExecutor;
 import com.google.devtools.build.lib.skyframe.config.BaselineOptionsFunction;
 import com.google.devtools.build.lib.skyframe.config.BuildConfigurationKey;
-import com.google.devtools.build.lib.skyframe.config.BuildConfigurationKeyValue;
 import com.google.devtools.build.lib.skyframe.config.PlatformMappingException;
 import com.google.devtools.build.lib.skyframe.toolchains.PlatformLookupUtil.InvalidPlatformException;
 import com.google.devtools.build.lib.testutil.TestRuleClassProvider;
@@ -811,11 +810,7 @@ public class BuildConfigurationKeyProducerTest extends ProducerTestCase {
     Sink sink = new Sink();
     BuildConfigurationKeyProducer<String> producer =
         new BuildConfigurationKeyProducer<>(
-            sink,
-            StateMachine.DONE,
-            CONTEXT,
-            BuildConfigurationKeyValue.Key.create(options),
-            label);
+            sink, StateMachine.DONE, CONTEXT, options, /* forBaseline= */ false, label);
     // Ignore the return value: sink will either return a result or re-throw whatever exception it
     // received from the producer.
     var unused = executeProducer(producer);

--- a/src/test/java/com/google/devtools/build/lib/skyframe/ConfigurationsForTargetsTest.java
+++ b/src/test/java/com/google/devtools/build/lib/skyframe/ConfigurationsForTargetsTest.java
@@ -198,10 +198,7 @@ public final class ConfigurationsForTargetsTest extends AnalysisTestCase {
                     : targetAndConfiguration.getConfiguration().getOptions(),
                 (bzlKey) ->
                     (BzlLoadValue) env.getValueOrThrow(bzlKey, BzlLoadFailedException.class),
-                (buildSettings, hostFlags) ->
-                    (StarlarkBuildSettingsDetailsValue)
-                        env.getValue(
-                            StarlarkBuildSettingsDetailsValue.key(buildSettings, hostFlags)));
+                detailsKey -> (StarlarkBuildSettingsDetailsValue) env.getValue(detailsKey));
         if (starlarkExecTransition == null) {
           return null;
         }


### PR DESCRIPTION
### Description

Follow-up to fmeum#21 (now merged), which fixed the memory regression on bazelbuild/bazel#28574 but left CPU at +2.6% and wall at +2.8% against the same baseline. This targets two sources of that CPU, both scaling with the size of the build graph rather than with the number of configurations.

**Scope details were resolved once per configured target.** `DependencyResolver`, `AspectFunction` and `SkyframeBuildView` call `loadStarlarkExecTransition` once per configured target / aspect, and it asked Skyframe for the `StarlarkBuildSettingsDetailsValue`. Interning stopped every node from retaining its own copy of the key, but the dependency edge itself remained: each node gained a dep, and one node accumulated a reverse dep per configured target. The value is a pure function of the configuration's Starlark flags, and there are far fewer configurations than targets, so `BuildConfigurationFunction` now resolves it and stores it on `BuildConfigurationValue`. The three call sites read it from the configuration they already depend on, so invalidation still works through the existing edge.

* `StarlarkExecTransitionLoader.execScopeDetailsKey(BuildOptions)` is extracted so the key is computed identically in both places, and `BuildSettingsDetailsLoader` now takes the key. The condition under which a key is needed is unchanged.
* `SkyframeExecutor` keeps evaluating through Skyframe: it has no configuration in hand.
* The field is excluded from `BuildConfigurationValue.equals`, being derived from `buildOptions`.

**A SkyKey was minted per transitioned dependency edge.** `TransitionApplier` wrapped every transition result in a `BuildConfigurationKeyValue.Key`, which `BuildConfigurationKeyMapProducer` immediately unpacked into `BuildConfigurationKeyProducer`'s build options and `forBaseline` flag. The key was never looked up in Skyframe on that path — it was purely a two-field parameter carrier — but creating one still costs a `SkyKeyInterner.intern` per edge, which during evaluation routes through `PooledInterner` into the graph's node map. The two values are now passed explicitly: `BuildConfigurationKeyMapProducer` goes back to taking a `Map<String, BuildOptions>` with `forBaseline` as a separate argument, and `BuildConfigurationKeyFunction` (the one caller that starts from a real `BuildConfigurationKeyValue.Key`) unpacks it there.

Also swaps `BuildConfigurationKeyValue.Key.hashCode` from `Objects.hash` to `HashCodes.hashObjects`, dropping the varargs array allocation. The boolean autoboxes to a cached `Boolean`, so the existing `(Object, Object)` overload suffices and the hash values are unchanged.

Of the three, the per-configured-target edge is the one most likely to show up in a benchmark; the other two are the kind of thing JIT escape analysis may already absorb. If CPU is still meaningfully above baseline after this, the cheapest next diagnostic is to stub the details lookup out entirely (`scopeDetails = null`, no `env.getValue`) for a single run and see whether CPU returns to baseline — that tells you whether the remaining cost is even in this area before anything else gets redesigned.

### Motivation

Close out the CPU half of the regression reported on bazelbuild/bazel#28574 before the branch lands.

Not addressed here, but worth a look: `FunctionSplitTransition.equals`/`hashCode` ignore `scopeDetails` while `split()` uses it. That appears safe today because `scopeDetails` is a deterministic function of the config's Starlark flags and `StarlarkTransitionCache.Key` includes `fromOptions`, but it silently becomes a wrong-result bug if the details ever stop being derived purely from `fromOptions`, so it may deserve a comment.

### Build API Changes

No

### Checklist

- [ ] I have added tests for the new use cases (if any).
- [ ] I have updated the documentation (if applicable).

Two things still to check with a real build, as this has not been compiled or tested:

- `BuildConfigurationValue` is `@AutoCodec` with a sole constructor, so the new parameter is serialized into every config. Configs are few, so the size cost should be negligible, but the serialized form does change.
- `analysis/config:build_configuration` now depends on `analysis:starlark/starlark_build_settings_details_value`. The reverse direction looks clear (that target's deps are `analysis/config:scope`, `cmdline`, `packages`, `sky_functions`, `autocodec`, none of which reach `build_configuration`), but only a real build rules out a cycle.

### Release Notes

RELNOTES: None